### PR TITLE
Rename `mix copy` command to `mix command`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ It uses a layered architecture (CLI -> Commands -> Core -> Storage) and relies o
 
 - **Run Application**:
     - `mix list`: List all available snippets.
-    - `mix <snippet>`: Copy a specific snippet to the clipboard.
+    - `mix command <snippet>`: Copy a specific snippet to the clipboard.
     - `mix touch <key>` / `mix t <key>`: Create context files in `.mix/` directory.
         - Supports predefined aliases (tk, rq, rv, df, pdt, pdr, wn, er)
         - Supports dynamic paths with auto `.md` extension and directory creation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `mix` is a Rust CLI that unifies two daily workflows:
 
-1. **Snippet copying** – type `mix copy <snippet>` (alias `mix c`) to stream any markdown snippet under
+1. **Snippet command** – type `mix command <snippet>` (alias `mix c`) to stream any markdown snippet under
    `~/.config/mix/commands/` into your clipboard.
 2. **Context Orchestration** – type `mix touch <key>` (alias `mix t`) to create or manage context files in your project.
 
@@ -29,7 +29,7 @@ mix list (alias: ls)
 mix --version
 
 # Copy a snippet into the clipboard (uses pbcopy/wl-copy/xclip/clip automatically)
-mix copy wc (alias: mix c wc)
+mix command wc (alias: mix c wc)
 
 # Create context files (alias: mix t)
 mix touch tk   # Creates .mix/tasks.md

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ enum Commands {
     },
     /// Copy a snippet to the clipboard
     #[command(visible_alias = "c")]
-    Copy { snippet: String },
+    Command { snippet: String },
 }
 
 fn main() {
@@ -45,7 +45,7 @@ fn main() {
         Some(Commands::List) => handle_list(),
         Some(Commands::Touch { key, paste, force }) => handle_touch(&key, paste, force),
         Some(Commands::Clean { key }) => handle_clean(key),
-        Some(Commands::Copy { snippet }) => handle_copy(&snippet),
+        Some(Commands::Command { snippet }) => handle_command(&snippet),
         None => {
             Cli::command().print_help().ok();
             println!();
@@ -59,7 +59,7 @@ fn main() {
     }
 }
 
-fn handle_copy(name: &str) -> Result<(), AppError> {
+fn handle_command(name: &str) -> Result<(), AppError> {
     let CopyOutcome { key, relative_path, absolute_path } = commands::copy_snippet(name)?;
     println!("✅ Copied '{key}' from {relative_path} -> {}", absolute_path.display());
     Ok(())

--- a/tests/cli_command.rs
+++ b/tests/cli_command.rs
@@ -5,7 +5,7 @@ use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 
-fn test_copy_variant(args: &[&str], clipboard_name: &str) {
+fn test_command_variant(args: &[&str], clipboard_name: &str) {
     let ctx = TestContext::new();
     ctx.install_sample_catalog();
     let clipboard = ctx.clipboard_file(clipboard_name);
@@ -18,26 +18,26 @@ fn test_copy_variant(args: &[&str], clipboard_name: &str) {
 
 #[test]
 #[serial]
-fn copy_subcommand_works() {
-    test_copy_variant(&["copy", "wc"], "clipboard.txt");
+fn command_subcommand_works() {
+    test_command_variant(&["command", "wc"], "clipboard.txt");
 }
 
 #[test]
 #[serial]
-fn copy_alias_c_works() {
-    test_copy_variant(&["c", "wc"], "clipboard_alias.txt");
+fn command_alias_c_works() {
+    test_command_variant(&["c", "wc"], "clipboard_alias.txt");
 }
 
 #[test]
 #[serial]
-fn copy_subcommand_missing_snippet_fails() {
+fn command_subcommand_missing_snippet_fails() {
     let ctx = TestContext::new();
     ctx.install_sample_catalog();
     let _ = ctx.clipboard_file("clipboard_fail.txt");
 
-    // Test `mix copy unknown`
+    // Test `mix command unknown`
     ctx.cli()
-        .arg("copy")
+        .arg("command")
         .arg("unknown")
         .assert()
         .failure()

--- a/tests/cli_flow.rs
+++ b/tests/cli_flow.rs
@@ -14,9 +14,9 @@ fn user_can_list_copy_and_touch() {
     // 1. List
     ctx.cli().arg("list").assert().success().stdout(predicate::str::contains("wc"));
 
-    // 2. Copy
+    // 2. Command
     let clipboard = ctx.clipboard_file("flow.txt");
-    ctx.cli().args(["c", "wc"]).assert().success();
+    ctx.cli().args(["command", "wc"]).assert().success();
     let clip = fs::read_to_string(clipboard).expect("clipboard file available");
     assert!(clip.contains("/wc"));
 


### PR DESCRIPTION
- Rename CLI subcommand `Copy` to `Command` in `src/main.rs`.
- Update alias `c` to point to `Command`.
- Rename `tests/cli_copy.rs` to `tests/cli_command.rs` and update test cases.
- Update `tests/cli_flow.rs` to use `command`.
- Update `README.md` and `AGENTS.md` to reflect the name change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated user-facing documentation to reflect command naming changes.

* **Refactor**
  * Renamed the "Snippet copying" command to "Snippet command" throughout the application and test suite.
  * Updated CLI usage patterns to use the new command name while maintaining all existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->