### PR TITLE
docs(qa): report test isolation issues

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/test-isolation-concurrency.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/test-isolation-concurrency.yml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+# Metadata
+id: "ti30c9"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "qa"
+confidence: "high"
+
+# Content
+title: "Global State Leakage in Integration Tests Forces Serial Execution"
+statement: |
+  The `TestContext` helper in `tests/common/mod.rs` modifies the process-global `HOME` environment variable via `env::set_var`, forcing all dependent tests (`copy`, `list`) to run serially. Additionally, `clean` tests are marked `#[serial]` unnecessarily, further reducing feedback speed.
+
+# Evidence supporting the observation
+evidence:
+  - path: "tests/common/mod.rs"
+    loc:
+      - "impl TestContext"
+      - "env::set_var(\"HOME\", root.path())"
+    note: "Modifies global environment, preventing parallel test execution."
+
+  - path: "tests/commands/copy.rs"
+    loc:
+      - "#[serial]"
+    note: "Required due to global state modification in TestContext."
+
+  - path: "tests/commands/clean.rs"
+    loc:
+      - "#[serial]"
+    note: "Marked serial despite using isolated tempdir and no global state modification."
+
+tags:
+  - "test-isolation"
+  - "concurrency"
+  - "performance"
+  - "anti-pattern"

--- a/.jules/workstreams/generic/workstations/qa/histories/20260202-abc1234.yml
+++ b/.jules/workstreams/generic/workstations/qa/histories/20260202-abc1234.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+id: "abc1234"
+created_at: "2026-02-02T23:59:59Z"
+
+observer: "qa"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Analyze integration tests for isolation and concurrency.
+  2. Identify global state usage in test helpers.
+  3. Report findings on unnecessary serialization.
+
+actions:
+  - "Analyzed tests/common/mod.rs and identified env::set_var usage."
+  - "Analyzed tests/commands/clean.rs and identified unnecessary #[serial]."
+  - "Created event ti30c9."
+
+outcomes:
+  summary: "Identified test isolation issues causing slow serial execution."
+  emitted_events:
+    - "ti30c9"
+  notes: |
+    TestContext modifies global env vars, forcing serial execution for tests that use it.
+    Newer tests (touch, cat) use tempdir correctly and avoid this, but clean.rs copies the serial pattern unnecessarily.
+
+perspective_updates:
+  goals_delta:
+    - "Identify and report test isolation issues to improve feedback speed."
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/qa/perspective.yml
+++ b/.jules/workstreams/generic/workstations/qa/perspective.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+
+observer: "qa"
+workstream: "generic"
+
+updated_at: "2026-02-02T23:59:59Z"
+
+goals:
+  short_term:
+    - "Identify and report test isolation issues to improve feedback speed."
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-02T23:59:59Z"
+    summary: "Identified test isolation issues causing slow serial execution."
+    history_path: ".jules/workstreams/generic/workstations/qa/histories/20260202-abc1234.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Created event and history files documenting test isolation issues caused by global state modification in integration tests.

---
*PR created automatically by Jules for task [5461683980694146675](https://jules.google.com/task/5461683980694146675) started by @akitorahayashi*