### PR TITLE
observer: data_arch analysis for nr7x9p

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/context-domain-coupling.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/context-domain-coupling.yml
@@ -1,0 +1,36 @@
+schema_version: 1
+
+id: "cdcp01"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "high"
+
+title: "Context file domain logic coupled to touch command"
+statement: |
+  Logic for managing project context files (path resolution, aliases, validation) is implemented in `src/commands/touch.rs` but reused by `cat`, `clean`, and `copy_snippet` commands. This creates a dependency on a command module for domain logic, violating separation of concerns.
+
+evidence:
+  - path: "src/commands/touch.rs"
+    loc:
+      - "fn resolve_path"
+      - "fn validate_path"
+      - "static ALIASES"
+    note: "Defines core context file logic but is a command module."
+  - path: "src/commands/cat.rs"
+    loc:
+      - "use crate::commands::touch::{...}"
+    note: "Imports context logic from touch command."
+  - path: "src/commands/clean.rs"
+    loc:
+      - "use crate::commands::touch::{...}"
+    note: "Imports context logic from touch command."
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "use crate::commands::touch::{...}"
+    note: "Imports context logic from touch command."
+
+tags:
+  - "coupling"
+  - "domain-logic"
+  - "context-files"

--- a/.jules/workstreams/generic/exchange/events/pending/dead-list-entry-fields.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/dead-list-entry-fields.yml
@@ -1,0 +1,23 @@
+schema_version: 1
+
+id: "dle001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "high"
+
+title: "Dead fields in ListEntry struct"
+statement: |
+  `ListEntry` struct contains `title` and `description` fields which are always `None` as metadata support has been deprecated/removed. This results in misleading data models and unnecessary Optional wrapping.
+
+evidence:
+  - path: "src/commands/list_snippets.rs"
+    loc:
+      - "struct ListEntry"
+      - "fn list"
+    note: "Fields are defined but always populated with None."
+
+tags:
+  - "dead-code"
+  - "data-model"
+  - "inefficiency"

--- a/.jules/workstreams/generic/exchange/events/pending/duplicate-snippet-models.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/duplicate-snippet-models.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+id: "dsm001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "high"
+
+title: "Redundant SnippetFile and CopyOutcome definitions"
+statement: |
+  `SnippetFile` (internal storage representation) and `CopyOutcome` (command DTO) are structurally identical. The transformation in `CopySnippet::execute` is a direct field-for-field copy, creating unnecessary code duplication and maintenance burden.
+
+evidence:
+  - path: "src/storage.rs"
+    loc:
+      - "struct SnippetFile"
+    note: "Internal storage representation."
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "struct CopyOutcome"
+      - "fn execute"
+    note: "Identical command output struct and 1:1 mapping."
+
+tags:
+  - "redundancy"
+  - "data-model"
+  - "duplication"

--- a/.jules/workstreams/generic/workstations/data_arch/histories/20260202-nr7x9p.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/histories/20260202-nr7x9p.yml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+id: "nr7x9p"
+created_at: "2026-02-02T23:40:23Z"
+
+observer: "data_arch"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  Analyze data models and flow efficiency. Focus on redundant definitions and coupling issues exposed by recent changes (touch, cat, storage migration).
+
+actions:
+  - "Analyzed src/storage.rs for data models."
+  - "Analyzed src/commands/ for command implementations and dependencies."
+  - "Identified coupling of context logic in touch.rs."
+  - "Identified redundant snippet models."
+  - "Identified dead fields in ListEntry."
+  - "Created 3 event files."
+
+outcomes:
+  summary: "Identified 3 data architecture issues: coupling in touch command, redundant snippet models, and dead code."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/context-domain-coupling.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/duplicate-snippet-models.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/dead-list-entry-fields.yml"
+  notes: |
+    The `touch` command has effectively become a library for context file operations, which is an anti-pattern.
+    Snippet data models are duplicated across storage and command layers without value.
+    Cleanup of deprecated metadata fields was incomplete in `ListEntry`.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/data_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "data_arch"
+workstream: "generic"
+
+updated_at: "2026-02-02T23:40:23Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-02T23:40:23Z"
+    summary: "Identified 3 data architecture issues: coupling in touch command, redundant snippet models, and dead code."
+    history_path: ".jules/workstreams/generic/workstations/data_arch/histories/20260202-nr7x9p.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Execution of data_arch observer role. Created event files for identified issues and updated workstation history/perspective.

---
*PR created automatically by Jules for task [1270635125642467877](https://jules.google.com/task/1270635125642467877) started by @akitorahayashi*