### PR TITLE
docs: taxonomy observations on mx naming inconsistencies

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/project-root-naming.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/project-root-naming.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+# Metadata
+id: "ev3prt"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "taxonomy"
+confidence: "medium"
+
+# Content
+title: "Project Root Semantic Mismatch"
+statement: |
+  The term "Project Root" and documentation imply semantic detection (e.g., git root), but the implementation relies solely on the Current Working Directory.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/touch.rs"
+    loc:
+      - "std::env::current_dir().map_err(AppError::Io)"
+    note: "find_project_root() simply returns current_dir()."
+  - path: "README.md"
+    loc:
+      - "runs outside of a project (project root cannot be detected)"
+    note: "Implies a failure mode or detection logic that does not exist."
+
+tags:
+  - "naming-semantics"
+  - "doc-code-mismatch"

--- a/.jules/workstreams/generic/exchange/events/pending/snippet-vs-command.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/snippet-vs-command.yml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+# Metadata
+id: "ev1snp"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Inconsistent Terminology for Snippets/Commands"
+statement: |
+  The concept of a reusable text fragment is referred to as "Snippet" in internal types, list output, and some documentation, but as "Command" in the CLI subcommand, storage directory structure, and aliases.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/main.rs"
+    loc:
+      - "Command { snippet: String }"
+    note: "CLI subcommand is named 'Command', but takes a 'snippet' argument."
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "pub(crate) struct CopySnippet"
+    note: "Internal logic uses 'Snippet' naming."
+  - path: "src/storage.rs"
+    loc:
+      - "root.join(\"commands\")"
+    note: "Storage directory is hardcoded to 'commands'."
+  - path: "src/main.rs"
+    loc:
+      - "list_snippets()?"
+    note: "List operation refers to 'snippets'."
+  - path: "README.md"
+    loc:
+      - "mx command <snippet>"
+    note: "User documentation mixes both terms in the same instruction."
+
+tags:
+  - "naming-collision"
+  - "cli-consistency"

--- a/.jules/workstreams/generic/exchange/events/pending/touch-naming.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/touch-naming.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+# Metadata
+id: "ev2tch"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "taxonomy"
+confidence: "medium"
+
+# Content
+title: "Touch Command Name Hides Pasting Behavior"
+statement: |
+  The `mx touch` command uses the Unix standard name "touch" (implying timestamp update or empty file creation) but defaults to pasting clipboard content into the file. This hidden side effect contradicts the established semantic of "touch".
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/touch.rs"
+    loc:
+      - "let clipboard = clipboard_from_env()?;"
+    note: "Clipboard access and pasting happens automatically in the main logic flow."
+  - path: "README.md"
+    loc:
+      - "mx touch <key> ... to create context files ... automatically pastes clipboard contents"
+    note: "Documentation confirms pasting is the default behavior, divergent from standard 'touch'."
+
+tags:
+  - "naming-semantics"
+  - "user-surprise"

--- a/.jules/workstreams/generic/workstations/taxonomy/histories/20260202-nr7x9p.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/histories/20260202-nr7x9p.yml
@@ -1,0 +1,38 @@
+schema_version: 1
+
+id: "nr7x9p"
+created_at: "2026-02-02T23:45:00Z"
+
+observer: "taxonomy"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Analyze codebase for naming inconsistencies.
+  2. Identify issues with 'Snippet' vs 'Command', 'Touch' semantics, and 'Project Root' definition.
+  3. Emit event files for each observation.
+  4. Update workstation history.
+
+actions:
+  - type: "create_event"
+    description: "Created snippet-vs-command.yml"
+  - type: "create_event"
+    description: "Created touch-naming.yml"
+  - type: "create_event"
+    description: "Created project-root-naming.yml"
+
+outcomes:
+  summary: "Identified 3 naming inconsistencies."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/snippet-vs-command.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/touch-naming.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/project-root-naming.yml"
+  notes: |
+    Found significant ambiguity in the core concepts of the tool.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "taxonomy"
+workstream: "generic"
+
+updated_at: "2026-02-02T23:45:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-02T23:45:00Z"
+    summary: "Identified 3 naming inconsistencies."
+    history_path: ".jules/workstreams/generic/workstations/taxonomy/histories/20260202-nr7x9p.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Executed the taxonomy observer role.
Identified and documented 3 naming inconsistencies:
1. Snippet vs Command terminology.
2. Touch command semantics (hidden paste).
3. Project Root definition (doc vs code).

Created event files in `.jules/workstreams/generic/exchange/events/pending/` and updated workstation history.

---
*PR created automatically by Jules for task [17713777949508832809](https://jules.google.com/task/17713777949508832809) started by @akitorahayashi*