### PR TITLE
chore: record rustacean observer findings

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/hidden-io-failures-in-placeholders.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/hidden-io-failures-in-placeholders.yml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: uztfw1
+issue_id: ''
+created_at: '2026-02-02'
+author_role: rustacean
+confidence: high
+title: hidden-io-failures-in-placeholders
+statement: The `render_placeholder` function catches file read errors and returns
+  a formatted string instead of propagating the error. This hides failures and prevents
+  the caller from detecting missing dependencies or permission issues.
+evidence:
+- path: src/commands/copy_snippet.rs
+  loc:
+  - render_placeholder
+  note: catches fs::read_to_string error and returns formatted string
+tags:
+- defect
+- error-handling

--- a/.jules/workstreams/generic/exchange/events/pending/lossy-error-model.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/lossy-error-model.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: wq4x4a
+issue_id: ''
+created_at: '2026-02-02'
+author_role: rustacean
+confidence: high
+title: lossy-error-model
+statement: The `AppError` type and its usage eagerly convert underlying errors (WalkDir,
+  IO) to strings, discarding type information and context needed for programmatic
+  handling or debugging.
+evidence:
+- path: src/storage.rs
+  loc:
+  - enumerate_snippets
+  note: WalkDir error converted to string via config_error
+- path: src/commands/clipboard.rs
+  loc:
+  - impl Clipboard for SystemClipboard
+  note: IO errors mapped to stringly-typed ClipboardError
+tags:
+- refactor
+- error-handling

--- a/.jules/workstreams/generic/exchange/events/pending/unnecessary-cloning-in-storage.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/unnecessary-cloning-in-storage.yml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: cjkw75
+issue_id: ''
+created_at: '2026-02-02'
+author_role: rustacean
+confidence: high
+title: unnecessary-cloning-in-storage
+statement: The `join_paths` function clones `relative_path` strings solely for the
+  purpose of joining them into a display string, creating unnecessary allocations.
+evidence:
+- path: src/storage.rs
+  loc:
+  - join_paths
+  note: maps with clone() before join
+tags:
+- refactor
+- performance
+- ownership

--- a/.jules/workstreams/generic/workstations/rustacean/histories/20260202-zk1tvw.yml
+++ b/.jules/workstreams/generic/workstations/rustacean/histories/20260202-zk1tvw.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: zk1tvw
+created_at: '2026-02-02T23:41:06Z'
+observer: rustacean
+workstream: generic
+inputs:
+  change_summary_path: .jules/changes/latest.yml
+plan: Analyze codebase and record findings regarding error handling and ownership.
+actions:
+- Read source code
+- Identified patterns matching anti-patterns
+- Created events
+outcomes:
+  summary: Analyzed codebase for ownership, error, and abstraction issues.
+  emitted_events:
+  - wq4x4a
+  - uztfw1
+  - cjkw75
+  notes: 'Identified 3 key areas for improvement: error model context, hidden I/O
+    failures, and unnecessary cloning.'
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/rustacean/perspective.yml
+++ b/.jules/workstreams/generic/workstations/rustacean/perspective.yml
@@ -1,0 +1,15 @@
+schema_version: 1
+observer: rustacean
+workstream: generic
+updated_at: '2026-02-02T23:41:06Z'
+goals:
+  short_term: []
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+recent_runs:
+- created_at: '2026-02-02T23:41:06Z'
+  summary: Analyzed codebase for ownership, error, and abstraction issues.
+  history_path: .jules/workstreams/generic/workstations/rustacean/histories/20260202-zk1tvw.yml
+learned_exclusions: []


### PR DESCRIPTION
Recorded findings from the rustacean observer role analysis. Identified issues with error model composition (lossy string conversion), hidden I/O failures in placeholder expansion, and unnecessary string cloning in storage logic. Created corresponding event files and updated the workstation history/perspective.

---
*PR created automatically by Jules for task [1328098334231034517](https://jules.google.com/task/1328098334231034517) started by @akitorahayashi*