### PR TITLE
Taxonomy Analysis: New Observations

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/inconsistent-cli-arg-naming.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/inconsistent-cli-arg-naming.yml
@@ -1,0 +1,35 @@
+schema_version: 1
+
+# Metadata
+id: "ican01"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Inconsistent CLI Argument Naming (key vs snippet)"
+statement: |
+  The CLI consistently uses the term `key` to refer to file identifiers across the `touch`, `cat`, and `clean` subcommands, as well as in internal data structures. However, the `mx command` subcommand breaks this pattern by naming its argument `snippet`, despite referring to the same concept (a file identifier/key).
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/main.rs"
+    loc:
+      - "Touch { key: String, ... }"
+      - "Cat { key: String }"
+      - "Clean { key: Option<String> }"
+    note: "Consistent usage of 'key'."
+  - path: "src/main.rs"
+    loc:
+      - "Command { snippet: String }"
+    note: "Divergent usage of 'snippet'."
+  - path: "src/storage.rs"
+    loc:
+      - "pub(crate) struct SnippetFile { pub key: String, ... }"
+    note: "Internal model uses 'key'."
+
+tags:
+  - "consistency"
+  - "cli-interface"
+  - "naming"

--- a/.jules/workstreams/generic/exchange/events/pending/legacy-slash-terminology.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/legacy-slash-terminology.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "lst001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Legacy 'Slash Command' Terminology in CLI Help"
+statement: |
+  The CLI help text description refers to "slash command generation", a legacy feature that has been removed from the codebase. This outdated terminology misleads users about the tool's current capabilities.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/main.rs"
+    loc:
+      - "#[command(about = \"Unified CLI for mx snippets and slash command generation\")]"
+    note: "Explicit reference to 'slash command generation'."
+
+tags:
+  - "legacy"
+  - "documentation"
+  - "user-confusion"

--- a/.jules/workstreams/generic/exchange/events/pending/misleading-error-naming.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/misleading-error-naming.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+# Metadata
+id: "men001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "taxonomy"
+confidence: "medium"
+
+# Content
+title: "Misleading AppError::config_error Usage"
+statement: |
+  The `AppError::config_error` variant is used as a catch-all for various runtime failures, including I/O errors (WalkDir), path manipulation errors, and data validation (UTF-8 checks). Labeling these as "configuration errors" obscures the root cause and conflates static configuration issues with dynamic runtime state.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/storage.rs"
+    loc:
+      - "AppError::config_error(err.to_string())"
+    note: "Used for WalkDir I/O errors."
+  - path: "src/storage.rs"
+    loc:
+      - "AppError::config_error(\"Unable to derive relative snippet path\")"
+    note: "Used for path logic errors."
+  - path: "src/storage.rs"
+    loc:
+      - "AppError::config_error(\"Snippet names must be valid UTF-8\")"
+    note: "Used for data validation errors."
+
+tags:
+  - "error-handling"
+  - "semantics"
+  - "observability"

--- a/.jules/workstreams/generic/exchange/events/pending/redundant-data-models.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/redundant-data-models.yml
@@ -1,0 +1,29 @@
+schema_version: 1
+
+# Metadata
+id: "rdm001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Redundant Data Models: SnippetFile and CopyOutcome"
+statement: |
+  The struct `CopyOutcome` in `src/commands/copy_snippet.rs` is structurally identical to `SnippetFile` in `src/storage.rs`. It duplicates the fields `key`, `relative_path`, and `absolute_path` without adding any new behavior or semantic distinction, creating unnecessary maintenance overhead.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/storage.rs"
+    loc:
+      - "pub(crate) struct SnippetFile"
+    note: "Original definition of the data structure."
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "pub struct CopyOutcome"
+    note: "Redundant re-definition with identical fields."
+
+tags:
+  - "redundancy"
+  - "data-model"
+  - "maintenance"

--- a/.jules/workstreams/generic/workstations/taxonomy/histories/20260202-abc123.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/histories/20260202-abc123.yml
@@ -1,0 +1,39 @@
+schema_version: 1
+
+id: "abc123"
+created_at: "2026-02-02T23:55:00Z"
+
+observer: "taxonomy"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml" # Implicitly used via prompt
+  perspective_path: ".jules/workstreams/generic/workstations/taxonomy/perspective.yml"
+
+plan: |
+  1. Analyze codebase for naming inconsistencies, focusing on CLI args, error handling, and legacy terms.
+  2. Verify findings against existing issues/events.
+  3. Create event files for new findings.
+  4. Update workstation history and perspective.
+
+actions:
+  - "Created event: redundant-data-models.yml"
+  - "Created event: legacy-slash-terminology.yml"
+  - "Created event: misleading-error-naming.yml"
+  - "Created event: inconsistent-cli-arg-naming.yml"
+
+outcomes:
+  summary: "Identified 4 new taxonomy issues including legacy terms, misleading error naming, and inconsistent CLI args."
+  emitted_events:
+    - "rdm001"
+    - "lst001"
+    - "men001"
+    - "ican01"
+  notes: |
+    Found significant conceptual drift in 'AppError::config_error' usage.
+    Confirmed 'slash command' legacy reference in CLI help.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
@@ -3,7 +3,7 @@ schema_version: 1
 observer: "taxonomy"
 workstream: "generic"
 
-updated_at: "2026-02-02T23:45:00Z"
+updated_at: "2026-02-02T23:55:00Z"
 
 goals:
   short_term: []
@@ -14,6 +14,9 @@ biases:
   heuristics: []
 
 recent_runs:
+  - created_at: "2026-02-02T23:55:00Z"
+    summary: "Identified 4 new taxonomy issues including legacy terms, misleading error naming, and inconsistent CLI args."
+    history_path: ".jules/workstreams/generic/workstations/taxonomy/histories/20260202-abc123.yml"
   - created_at: "2026-02-02T23:45:00Z"
     summary: "Identified 3 naming inconsistencies."
     history_path: ".jules/workstreams/generic/workstations/taxonomy/histories/20260202-nr7x9p.yml"


### PR DESCRIPTION
This PR adds 4 new observation events identifying taxonomy issues in the codebase:
1. Redundant data models (`SnippetFile` vs `CopyOutcome`).
2. Legacy "slash command" terminology in CLI help.
3. Misleading usage of `AppError::config_error` for runtime/IO errors.
4. Inconsistent CLI argument naming (`key` vs `snippet`).

It also updates the taxonomy observer's workstation history and perspective.

---
*PR created automatically by Jules for task [5621452899726398010](https://jules.google.com/task/5621452899726398010) started by @akitorahayashi*