### PR TITLE
observer(qa): report touch test isolation and redundancy

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/global-cwd-modification-in-unit-tests.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/global-cwd-modification-in-unit-tests.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+# Metadata
+id: "x7k9m2"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "qa"
+confidence: "high"
+
+# Content
+title: "Unit Tests Modify Global CWD Preventing Parallel Execution"
+statement: |
+  Unit tests in `src/commands/touch.rs` use `std::env::set_current_dir` to mock the project root. This modifies the global state of the test process, forcing these tests to run serially and potentially interfering with other tests running in parallel within the same binary.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/touch.rs"
+    loc:
+      - "std::env::set_current_dir(&dir).unwrap();"
+    note: "Modifies global CWD, requiring #[serial] and risking side effects."
+
+tags:
+  - "test-isolation"
+  - "concurrency"
+  - "global-state"
+  - "anti-pattern"

--- a/.jules/workstreams/generic/exchange/events/pending/redundant-touch-tests.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/redundant-touch-tests.yml
@@ -1,0 +1,31 @@
+schema_version: 1
+
+# Metadata
+id: "r3d8n9"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "qa"
+confidence: "high"
+
+# Content
+title: "Redundant Integration and Unit Tests for Touch Command"
+statement: |
+  The `mx touch` command logic is extensively tested in `src/commands/touch.rs` (unit tests) and again in `tests/commands/touch.rs` (integration tests). Both suites verify the same file creation, path resolution, and error handling behaviors. The integration tests are significantly slower due to process spawning and provide less granular failure feedback.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/touch.rs"
+    loc:
+      - "mod tests"
+    note: "Comprehensive unit tests covering aliasing, path resolution, and file creation."
+  - path: "tests/commands/touch.rs"
+    loc:
+      - "touch_creates_context_files"
+      - "touch_nested_files"
+      - "touch_dynamic_simple"
+    note: "Slow integration tests duplicating unit test coverage."
+
+tags:
+  - "test-redundancy"
+  - "feedback-speed"
+  - "maintenance-burden"

--- a/.jules/workstreams/generic/workstations/qa/histories/20260203-x7k9m2.yml
+++ b/.jules/workstreams/generic/workstations/qa/histories/20260203-x7k9m2.yml
@@ -1,0 +1,36 @@
+schema_version: 1
+
+id: "h5j2k8"
+created_at: "2026-02-03T00:05:00Z"
+
+observer: "qa"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Explore codebase and tests.
+  2. Identify test isolation and redundancy issues.
+  3. Emit events for CWD modification and redundant tests.
+  4. Update workstation state.
+
+actions:
+  - "Analyzed tests/common/mod.rs for isolation issues."
+  - "Analyzed src/commands/touch.rs and tests/commands/touch.rs for redundancy and CWD modification."
+  - "Created event global-cwd-modification-in-unit-tests.yml."
+  - "Created event redundant-touch-tests.yml."
+
+outcomes:
+  summary: "Identified critical global state leaks in unit tests and redundant testing patterns."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/global-cwd-modification-in-unit-tests.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/redundant-touch-tests.yml"
+  notes: |
+    Found that src/commands/touch.rs modifies process-global CWD, forcing serial execution.
+    Found significant overlap between touch unit and integration tests.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/qa/perspective.yml
+++ b/.jules/workstreams/generic/workstations/qa/perspective.yml
@@ -3,7 +3,7 @@ schema_version: 1
 observer: "qa"
 workstream: "generic"
 
-updated_at: "2026-02-02T23:59:59Z"
+updated_at: "2026-02-03T00:05:00Z"
 
 goals:
   short_term:
@@ -15,6 +15,9 @@ biases:
   heuristics: []
 
 recent_runs:
+  - created_at: "2026-02-03T00:05:00Z"
+    summary: "Identified critical global state leaks in unit tests and redundant testing patterns."
+    history_path: ".jules/workstreams/generic/workstations/qa/histories/20260203-x7k9m2.yml"
   - created_at: "2026-02-02T23:59:59Z"
     summary: "Identified test isolation issues causing slow serial execution."
     history_path: ".jules/workstreams/generic/workstations/qa/histories/20260202-abc1234.yml"


### PR DESCRIPTION
Reported two QA events: global CWD modification in touch unit tests and redundant integration testing for touch command.

---
*PR created automatically by Jules for task [1836435672551924819](https://jules.google.com/task/1836435672551924819) started by @akitorahayashi*