### PR TITLE
devops: analyze ci/cd workflows and emit findings

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/excessive-ci-scope.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/excessive-ci-scope.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: "xc8j1p"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "devops"
+confidence: "high"
+title: "Excessive CI Scope: Building Release Artifacts in PRs"
+statement: |
+  The `ci-workflows.yml` invokes `build.yml` which unconditionally runs the `build-release` job for all four target platforms (Linux/macOS x x86/ARM). This expensive operation runs on every Pull Request, significantly slowing down the developer feedback loop and wasting CI resources, when `cargo test` (running debug builds) would suffice for verification.
+evidence:
+  - path: ".github/workflows/ci-workflows.yml"
+    loc:
+      - "30"
+    note: "Invokes build.yml on PRs without filtering jobs"
+  - path: ".github/workflows/build.yml"
+    loc:
+      - "19"
+      - "30"
+    note: "Defines build-release matrix for 4 targets, running on every invocation"
+tags:
+  - "feedback-loop"
+  - "efficiency"

--- a/.jules/workstreams/generic/exchange/events/pending/over-permissioned-workflows.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/over-permissioned-workflows.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+id: "op4k3m"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "devops"
+confidence: "high"
+title: "Over-permissioned Build Job in Release Workflow"
+statement: |
+  The `.github/workflows/release.yml` grants `contents: write` permission to the entire workflow. This permission is inherited by the `build` job, which executes `cargo build` and potentially untrusted build scripts/dependencies. If a dependency is compromised, it could abuse this permission to modify the repository or release assets. The `build` job should operate with `contents: read` (or less), and only the `release` job needs `contents: write`.
+evidence:
+  - path: ".github/workflows/release.yml"
+    loc:
+      - "10"
+    note: "Top-level permissions grant contents: write to all jobs"
+  - path: ".github/workflows/release.yml"
+    loc:
+      - "13"
+    note: "Build job inherits write permissions while running cargo build"
+tags:
+  - "security"
+  - "least-privilege"

--- a/.jules/workstreams/generic/exchange/events/pending/unverified-binary-download.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/unverified-binary-download.yml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: "vb9x2q"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "devops"
+confidence: "high"
+title: "Unverified Binary Download in CI"
+statement: |
+  The `install-jlo` action downloads the `jlo` binary from a GitHub Release URL using `curl` without verifying a cryptographic checksum (SHA256). This exposes the pipeline to supply-chain attacks if the release asset is compromised or the URL is hijacked.
+evidence:
+  - path: ".github/actions/install-jlo/action.yml"
+    loc:
+      - "20"
+      - "27"
+    note: "curl downloads binary directly from URL without checksum verification"
+tags:
+  - "security"
+  - "supply-chain"

--- a/.jules/workstreams/generic/workstations/devops/histories/20260203-f72810.yml
+++ b/.jules/workstreams/generic/workstations/devops/histories/20260203-f72810.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+created_at: "2026-02-03T00:00:00Z"
+observer: "devops"
+workstream: "generic"
+inputs:
+  changes_summary_id: "nr7x9p"
+  perspective_updated_at: "2026-02-02T23:38:49Z"
+plan:
+  steps:
+    - "Analyze CI/CD workflows for safety, speed, and efficiency."
+    - "Identify unverified binary downloads."
+    - "Identify excessive CI scope in PRs."
+    - "Identify over-permissioned workflows."
+    - "Create event files for findings."
+actions:
+  - type: "create_event"
+    path: ".jules/workstreams/generic/exchange/events/pending/unverified-binary-download.yml"
+    summary: "Flagged install-jlo action for unverified curl download."
+  - type: "create_event"
+    path: ".jules/workstreams/generic/exchange/events/pending/excessive-ci-scope.yml"
+    summary: "Flagged ci-workflows.yml for running full release matrix on PRs."
+  - type: "create_event"
+    path: ".jules/workstreams/generic/exchange/events/pending/over-permissioned-workflows.yml"
+    summary: "Flagged release.yml for granting write permission to build job."
+outcomes:
+  events_emitted:
+    - "unverified-binary-download.yml"
+    - "excessive-ci-scope.yml"
+    - "over-permissioned-workflows.yml"
+  perspective_updates:
+    goals: []
+    biases: []
+    learned_exclusions: []

--- a/.jules/workstreams/generic/workstations/devops/perspective.yml
+++ b/.jules/workstreams/generic/workstations/devops/perspective.yml
@@ -3,7 +3,7 @@ schema_version: 1
 observer: "devops"
 workstream: "generic"
 
-updated_at: "2026-02-02T23:38:49Z"
+updated_at: "2026-02-03T00:00:00Z"
 
 goals:
   short_term: []
@@ -14,6 +14,9 @@ biases:
   heuristics: []
 
 recent_runs:
+  - created_at: "2026-02-03T00:00:00Z"
+    summary: "Identified unverified binary downloads, excessive CI scope, and over-permissioned workflows."
+    history_path: ".jules/workstreams/generic/workstations/devops/histories/20260203-f72810.yml"
   - created_at: "2026-02-02T23:38:49Z"
     summary: "Identified unpinned actions, toolchain drift between CI/Release, and duplicated build logic."
     history_path: ".jules/workstreams/generic/workstations/devops/histories/20260202-h8k2l9.yml"


### PR DESCRIPTION
Analyzed CI/CD workflows for security and efficiency issues. Emitted events for unverified binary downloads, excessive CI scope, and over-permissioned workflows. Updated workstation history and perspective.

---
*PR created automatically by Jules for task [13484441067950111068](https://jules.google.com/task/13484441067950111068) started by @akitorahayashi*