### PR TITLE
obs(consistency): record analysis results

### DIFF
--- a/.jules/workstreams/generic/workstations/consistency/histories/20260203-qcb67e.yml
+++ b/.jules/workstreams/generic/workstations/consistency/histories/20260203-qcb67e.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+id: "qcb67e"
+created_at: "2026-02-03T00:00:00Z"
+
+observer: "consistency"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  Analyze codebase changes (mx cat, mx touch, storage migration) against README.md and CLI help.
+  Check for documentation drift in aliases, flags, and descriptions.
+
+actions:
+  - "Analyzed README.md vs src/commands/touch.rs and src/main.rs"
+  - "Identified missing aliases in README (atk, rf, pl)"
+  - "Identified outdated 'slash command' reference in CLI help"
+  - "Found existing issue p6q7r8 covering these discrepancies"
+
+outcomes:
+  summary: "Verified documentation drift; all findings deduped against p6q7r8."
+  emitted_events: []
+  notes: |
+    Confirmed that p6q7r8 'Sync Documentation with Implementation' covers:
+    - Missing aliases (atk, rf, pl)
+    - Legacy slash command help text
+    No other significant drift found in the selected range.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/consistency/perspective.yml
+++ b/.jules/workstreams/generic/workstations/consistency/perspective.yml
@@ -3,7 +3,7 @@ schema_version: 1
 observer: "consistency"
 workstream: "generic"
 
-updated_at: "2026-02-02T23:45:00Z"
+updated_at: "2026-02-03T00:00:00Z"
 
 goals:
   short_term: []
@@ -14,6 +14,9 @@ biases:
   heuristics: []
 
 recent_runs:
+  - created_at: "2026-02-03T00:00:00Z"
+    summary: "Verified documentation drift; all findings deduped against p6q7r8."
+    history_path: ".jules/workstreams/generic/workstations/consistency/histories/20260203-qcb67e.yml"
   - created_at: "2026-02-02T23:45:00Z"
     summary: "Identified documentation drift regarding aliases and legacy descriptions."
     history_path: ".jules/workstreams/generic/workstations/consistency/histories/20260202-analysis.yml"


### PR DESCRIPTION
Recorded findings on documentation drift (aliases, help text) in history file and updated perspective. All findings were deduplicated against existing issue p6q7r8.

---
*PR created automatically by Jules for task [16664973097277299439](https://jules.google.com/task/16664973097277299439) started by @akitorahayashi*