### PR TITLE
Identify implicit file extension flaw in mx touch

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/implicit-file-extension-logic-flaw.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/implicit-file-extension-logic-flaw.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "x7d9f2"
+issue_id: "" # Pending
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Implicit File Extension Logic Flaw"
+statement: |
+  The `mx touch` command logic unconditionally appends `.md` to any filename that lacks an extension according to `Path::extension`. This incorrectly transforms standard dotfiles (e.g., `.gitignore`, `.env`) into markdown files (e.g., `.gitignore.md`), making it impossible to create functional configuration files via `mx touch`.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/touch.rs"
+    loc:
+      - "if path.extension().is_none() {"
+      - "path.set_extension(\"md\");"
+    note: "The `path.extension().is_none()` check considers filenames starting with a dot (and no other dots) as having no extension, triggering the `.md` append."
+
+tags:
+  - "data-transformation"
+  - "bug"

--- a/.jules/workstreams/generic/workstations/data_arch/histories/20260202-5e68d0.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/histories/20260202-5e68d0.yml
@@ -1,0 +1,35 @@
+schema_version: 1
+
+id: "5e68d0"
+created_at: "2026-02-02T23:45:00Z"
+
+observer: "data_arch"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Explore codebase to identify data architecture issues, focusing on new commands (cat, touch).
+  2. Analyze path resolution logic in `touch.rs` and its usage in `cat`, `clean`.
+  3. Verify extension handling for dotfiles.
+  4. Create event for identified flaw.
+
+actions:
+  - "Read src/commands/touch.rs to analyze resolve_path logic."
+  - "Read src/commands/cat.rs and clean.rs to confirm dependency on touch.rs."
+  - "Verified dotfile extension behavior with a reproduction script."
+  - "Created event implicit-file-extension-logic-flaw.yml."
+
+outcomes:
+  summary: "Identified a flaw in `mx touch` where dotfiles without extensions are incorrectly appended with `.md`."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/implicit-file-extension-logic-flaw.yml"
+  notes: |
+    The logic `if path.extension().is_none()` returns true for files like `.gitignore`, leading to `.gitignore.md`.
+    This contradicts the README claim that extensions are preserved (only true for files with standard extensions like .yaml).
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/data_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/perspective.yml
@@ -3,7 +3,7 @@ schema_version: 1
 observer: "data_arch"
 workstream: "generic"
 
-updated_at: "2026-02-02T23:40:23Z"
+updated_at: "2026-02-02T23:45:00Z"
 
 goals:
   short_term: []
@@ -14,6 +14,9 @@ biases:
   heuristics: []
 
 recent_runs:
+  - created_at: "2026-02-02T23:45:00Z"
+    summary: "Identified a flaw in `mx touch` where dotfiles without extensions are incorrectly appended with `.md`."
+    history_path: ".jules/workstreams/generic/workstations/data_arch/histories/20260202-5e68d0.yml"
   - created_at: "2026-02-02T23:40:23Z"
     summary: "Identified 3 data architecture issues: coupling in touch command, redundant snippet models, and dead code."
     history_path: ".jules/workstreams/generic/workstations/data_arch/histories/20260202-nr7x9p.yml"


### PR DESCRIPTION
Identified a flaw in `mx touch` where dotfiles without extensions (e.g., `.gitignore`) are incorrectly appended with `.md`. Created event `implicit-file-extension-logic-flaw.yml` and updated workstation history/perspective.

---
*PR created automatically by Jules for task [12704739696359822687](https://jules.google.com/task/12704739696359822687) started by @akitorahayashi*