### PR TITLE
docs: Sync Documentation with Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ mx t config.yaml     # Creates .mx/config.yaml (preserves extension)
 | pdr  | `.mx/pending/requirements.md`|
 | tko  | `.mx/tasks_outline.md`     |
 | tk   | `.mx/tasks.md`             |
+| atk  | `.mx/additional_tasks.md`  |
 | pdt  | `.mx/pending/tasks.md`     |
 | rv   | `.mx/review.md`            |
+| rf   | `.mx/reference.md`         |
+| pl   | `.mx/plan.md`              |
 
 ### Dynamic Path Resolution
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use mx::{CopyOutcome, ListEntry};
 #[derive(Parser)]
 #[command(name = "mx")]
 #[command(version)]
-#[command(about = "Unified CLI for mx snippets and slash command generation")]
+#[command(about = "Unified CLI for mx snippets")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
This PR synchronizes the documentation with the current implementation.

Changes:
1.  **README.md**: Added `atk`, `rf`, and `pl` to the "Context Management Keys (Aliases)" table.
2.  **src/main.rs**: Updated the `about` attribute in the `Cli` struct to remove the reference to "slash command generation", which is a legacy feature.

Verification:
- `grep 'atk' README.md` confirms the alias is present.
- `cargo run -- --help` confirms the help text is updated.
- `cargo test` confirms no regressions.

---
*PR created automatically by Jules for task [353648709164861301](https://jules.google.com/task/353648709164861301) started by @akitorahayashi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded Context Management Key aliases by adding three new shortcuts: atk (additional tasks), rf (reference), and pl (plan) for faster access to documentation paths

* **Refactor**
  * Updated CLI command description text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->