### PR TITLE
fix: mx touch correctly handles dotfiles

### DIFF
--- a/src/commands/touch.rs
+++ b/src/commands/touch.rs
@@ -69,7 +69,12 @@ pub fn resolve_path(key: &str) -> PathBuf {
 
     // 4. Extension completion (if no extension specified)
     if path.extension().is_none() {
-        path.set_extension("md");
+        // Only append .md if the file name does not start with a dot
+        // (to allow dotfiles like .gitignore, .env)
+        let file_name_str = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if !file_name_str.starts_with('.') {
+            path.set_extension("md");
+        }
     }
 
     path
@@ -296,6 +301,18 @@ mod tests {
     fn test_resolve_path_with_extension_md() {
         let path = resolve_path("notes.md");
         assert_eq!(path, PathBuf::from("notes.md"));
+    }
+
+    #[test]
+    fn test_resolve_path_dotfile_gitignore() {
+        let path = resolve_path(".gitignore");
+        assert_eq!(path, PathBuf::from(".gitignore"));
+    }
+
+    #[test]
+    fn test_resolve_path_dotfile_env() {
+        let path = resolve_path(".env");
+        assert_eq!(path, PathBuf::from(".env"));
     }
 
     // === validate_path tests ===


### PR DESCRIPTION
The `mx touch` command was unconditionally appending `.md` to filenames that appeared to have no extension (e.g. `.gitignore` -> `.gitignore.md`). This change adds a check to skip the default extension if the filename starts with a dot. Added regression tests.

---
*PR created automatically by Jules for task [14072407701704904580](https://jules.google.com/task/14072407701704904580) started by @akitorahayashi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file path resolution to correctly handle dotfiles (such as `.gitignore` and `.env`) by preventing unwanted `.md` extension additions.

* **Tests**
  * Added test coverage for dotfile handling to ensure correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->