### PR TITLE
docs: Add data architecture observation events

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/command-module-coupling.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/command-module-coupling.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+# Metadata
+id: "da04cc"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "High Coupling Between Command Modules"
+statement: |
+  The copy_snippet and cat command modules directly import logic (resolve_path, validate_path) from the touch module. This violates command isolation, making the touch module a de-facto shared library for path logic and creating a hidden dependency graph that complicates refactoring.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "use crate::commands::touch::validate_path"
+    note: "Direct dependency on touch module logic."
+  - path: "src/commands/cat.rs"
+    loc:
+      - "use crate::commands::touch::{resolve_path, validate_path}"
+    note: "Direct dependency on touch module logic."
+
+tags:
+  - "coupling"
+  - "modularization"

--- a/.jules/workstreams/generic/exchange/events/pending/dead-list-entry-fields.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/dead-list-entry-fields.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+# Metadata
+id: "da02dl"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Deprecated Metadata Fields in ListEntry"
+statement: |
+  The ListEntry struct retains title and description fields that are permanently set to None, creating a misleading data contract. This dead code implies functionality that has been removed and complicates the data model unnecessarily.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/list_snippets.rs"
+    loc:
+      - "ListEntry struct definition"
+    note: "Contains Option<String> fields for title and description."
+  - path: "src/commands/list_snippets.rs"
+    loc:
+      - "list function"
+    note: "Hardcodes title and description to None during mapping."
+
+tags:
+  - "dead-code"
+  - "misleading-model"

--- a/.jules/workstreams/generic/exchange/events/pending/implicit-storage-config.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/implicit-storage-config.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+# Metadata
+id: "da03is"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Implicit Global State Dependency in Storage"
+statement: |
+  SnippetStorage couples configuration logic (reading HOME/MX_COMMANDS_ROOT env vars) directly into the domain model via the from_env constructor. This makes the storage layer difficult to test without modifying global process state and violates the boundary sovereignty principle.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/storage.rs"
+    loc:
+      - "SnippetStorage::from_env"
+    note: "Reads environment variables directly to construct the object."
+  - path: "src/lib.rs"
+    loc:
+      - "public library functions"
+    note: "Implicitly rely on this behavior via SnippetStorage::new_default() or similar patterns, obscuring dependencies."
+
+tags:
+  - "coupling"
+  - "testing-difficulty"

--- a/.jules/workstreams/generic/exchange/events/pending/lossy-error-types.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/lossy-error-types.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+
+# Metadata
+id: "da05le"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Lossy String Conversion in Error Handling"
+statement: |
+  The AppError type erases strong types into Strings (e.g. ConfigError(String)), preventing upstream handlers from reacting to specific failure modes. This practice forces string parsing for error handling logic and results in loss of diagnostic context.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/error.rs"
+    loc:
+      - "AppError enum definition"
+    note: "Variants like ConfigError, NotFound, ClipboardError wrapping String."
+
+tags:
+  - "error-handling"
+  - "type-erasure"

--- a/.jules/workstreams/generic/exchange/events/pending/redundant-snippet-models.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/redundant-snippet-models.yml
@@ -1,0 +1,29 @@
+schema_version: 1
+
+# Metadata
+id: "da01rs"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Redundant SnippetFile and CopyOutcome definitions"
+statement: |
+  SnippetFile and CopyOutcome structs share an identical schema representing a file reference, violating the Single Source of Truth principle. This duplication requires keeping two identical structures in sync without a clear boundary or conversion necessity.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/storage.rs"
+    loc:
+      - "SnippetFile struct definition"
+    note: "Defines key, relative_path, absolute_path."
+
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "CopyOutcome struct definition"
+    note: "Defines identical key, relative_path, absolute_path fields."
+
+tags:
+  - "data-duplication"
+  - "ssot-violation"

--- a/.jules/workstreams/generic/workstations/data_arch/histories/20260203-darch1.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/histories/20260203-darch1.yml
@@ -1,0 +1,38 @@
+schema_version: 1
+
+id: "darch1"
+created_at: "2026-02-03T00:00:00Z"
+
+observer: "data_arch"
+workstream: "generic"
+
+inputs:
+  change_summary_path: null
+
+plan: |
+  Analyze codebase for data architecture issues, specifically focusing on data model redundancy, coupling, and inefficient transformations.
+
+actions:
+  - "Read codebase files (src/lib.rs, src/storage.rs, src/commands/*, src/error.rs)."
+  - "Identified redundant SnippetFile and CopyOutcome."
+  - "Identified dead fields in ListEntry."
+  - "Identified implicit storage configuration."
+  - "Identified coupling between command modules."
+  - "Identified lossy error types."
+  - "Created 5 pending event files."
+
+outcomes:
+  summary: "Identified 5 data architecture issues."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/redundant-snippet-models.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/dead-list-entry-fields.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/implicit-storage-config.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/command-module-coupling.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/lossy-error-types.yml"
+  notes: |
+    Initial analysis of the codebase reveals several violations of data architecture principles, particularly around SSOT and modularity.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/data_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "data_arch"
+workstream: "generic"
+
+updated_at: "2026-02-03T00:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-03T00:00:00Z"
+    summary: "Identified 5 data architecture issues."
+    history_path: ".jules/workstreams/generic/workstations/data_arch/histories/20260203-darch1.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Added 5 pending events identifying data architecture issues (redundancy, coupling, dead code) and updated the data_arch workstation history/perspective.

---
*PR created automatically by Jules for task [6857874577826802164](https://jules.google.com/task/6857874577826802164) started by @akitorahayashi*