### PR TITLE
chore(devops): report ci/cd observation events

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/ci-resource-waste.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/ci-resource-waste.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+# Metadata
+id: "crw002"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "devops"
+confidence: "high"
+
+# Content
+title: "Excessive CI Resource Usage"
+statement: |
+  The `ci-workflows.yml` workflow triggers the `build.yml` workflow on every Pull Request.
+  `build.yml` executes a matrix of 4 jobs (Linux x86/ARM, macOS x86/ARM). This results in
+  heavy resource consumption (4 concurrent builds) for every commit pushed to a PR, slowing
+  down feedback and wasting minutes.
+
+# Evidence supporting the observation
+evidence:
+  - path: ".github/workflows/ci-workflows.yml"
+    loc:
+      - "20"
+    note: "Triggers build workflow on PRs."
+
+  - path: ".github/workflows/build.yml"
+    loc:
+      - "20-29"
+    note: "Defines a 4-target matrix including cross-compilation and macOS runners."
+
+tags:
+  - "performance"
+  - "ci-cd"
+  - "cost"

--- a/.jules/workstreams/generic/exchange/events/pending/install-jlo-no-checksum.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/install-jlo-no-checksum.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+# Metadata
+id: "jlo003"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "devops"
+confidence: "high"
+
+# Content
+title: "Unverified Binary Download in Install Action"
+statement: |
+  The `.github/actions/install-jlo` composite action downloads the `jlo` binary from GitHub Releases
+  using `curl` without verifying its checksum (SHA256). This exposes the pipeline to supply-chain attacks
+  if the release asset is compromised or the download URL is spoofed.
+
+# Evidence supporting the observation
+evidence:
+  - path: ".github/actions/install-jlo/action.yml"
+    loc:
+      - "83-89"
+    note: "Downloads binary via curl without checksum verification."
+
+tags:
+  - "security"
+  - "supply-chain"
+  - "actions"

--- a/.jules/workstreams/generic/exchange/events/pending/release-permissions.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/release-permissions.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+
+# Metadata
+id: "prm004"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "devops"
+confidence: "high"
+
+# Content
+title: "Excessive Permissions in Release Workflow"
+statement: |
+  The `release.yml` workflow grants `contents: write` permission at the workflow level.
+  This permission propagates to all jobs, including the `build` job which compiles code
+  and runs potentially untrusted build scripts (via `build.rs` or proc-macros).
+  The write permission should be scoped strictly to the `release` job.
+
+# Evidence supporting the observation
+evidence:
+  - path: ".github/workflows/release.yml"
+    loc:
+      - "11"
+    note: "Top-level permissions granting write access to all jobs."
+
+tags:
+  - "security"
+  - "permissions"
+  - "least-privilege"

--- a/.jules/workstreams/generic/exchange/events/pending/toolchain-drift.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/toolchain-drift.yml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+# Metadata
+id: "tcd001"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "devops"
+confidence: "high"
+
+# Content
+title: "Rust Toolchain Drift between CI and Release"
+statement: |
+  The CI environment diverges from the Release environment and the project configuration.
+  `rust-toolchain.toml` pins the toolchain to `1.90.0`, and `release.yml` respects this.
+  However, the `.github/actions/setup` composite action defaults to `stable` if no input is provided,
+  and `build.yml` (used by CI) calls it without inputs. This means CI runs on `stable` while Release
+  runs on `1.90.0`.
+
+# Evidence supporting the observation
+evidence:
+  - path: "rust-toolchain.toml"
+    loc:
+      - "2"
+    note: "Pins toolchain to 1.90.0."
+
+  - path: ".github/actions/setup/action.yml"
+    loc:
+      - "7"
+    note: "Defaults 'rust-version' input to 'stable'."
+
+  - path: ".github/workflows/build.yml"
+    loc:
+      - "15"
+      - "43"
+    note: "Calls setup action without specifying rust-version, thus using stable."
+
+  - path: ".github/workflows/release.yml"
+    loc:
+      - "30"
+    note: "Explicitly uses 1.90.0, matching the toml file."
+
+tags:
+  - "reproducibility"
+  - "drift"
+  - "toolchain"

--- a/.jules/workstreams/generic/workstations/devops/histories/20260203-1a2b3c.yml
+++ b/.jules/workstreams/generic/workstations/devops/histories/20260203-1a2b3c.yml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+id: "1a2b3c"
+created_at: "2026-02-03T10:00:00Z"
+
+observer: "devops"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  Analyze CI/CD workflows for reproducibility, security, and efficiency issues.
+
+actions:
+  - "Analyzed .github/workflows/ and .github/actions/"
+  - "Checked rust-toolchain.toml and Cargo.toml"
+  - "Created 4 event files for identified issues"
+
+outcomes:
+  summary: "Identified critical toolchain drift, security risks, and resource waste."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/toolchain-drift.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/ci-resource-waste.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/install-jlo-no-checksum.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/release-permissions.yml"
+  notes: |
+    The pipeline has significant drift between CI (stable) and Release (1.90.0).
+    Supply chain security is weak in the custom install action.
+    Release workflow has excessive permissions.
+
+perspective_updates:
+  goals_delta:
+    - "Monitor resolution of toolchain drift"
+    - "Monitor resolution of supply chain risks"
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/devops/perspective.yml
+++ b/.jules/workstreams/generic/workstations/devops/perspective.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+observer: "devops"
+workstream: "generic"
+
+updated_at: "2026-02-03T10:05:00Z"
+
+goals:
+  short_term:
+    - "Monitor resolution of toolchain drift"
+    - "Monitor resolution of supply chain risks"
+
+biases:
+  assumptions:
+    - "CI environment should mirror production/release environment exactly."
+  blind_spots: []
+  heuristics:
+    - "If a workflow runs on every PR, it must be optimized for speed."
+
+recent_runs:
+  - created_at: "2026-02-03T10:00:00Z"
+    summary: "Identified critical toolchain drift, security risks, and resource waste."
+    history_path: ".jules/workstreams/generic/workstations/devops/histories/20260203-1a2b3c.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Reported critical DevOps observations regarding CI/CD pipeline efficiency, security, and reproducibility. Generated corresponding event files and updated the observer's workstation state.

---
*PR created automatically by Jules for task [1667820653253640949](https://jules.google.com/task/1667820653253640949) started by @akitorahayashi*