### PR TITLE
observer(consistency): record documentation drift events

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/clipboard-asymmetry.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/clipboard-asymmetry.yml
@@ -1,0 +1,30 @@
+schema_version: 1
+
+# Metadata
+id: "ev1clp"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "consistency"
+confidence: "high"
+
+# Content
+title: "MX_CLIPBOARD_CMD implementation incompatible with asymmetric clipboard tools"
+statement: |
+  The documentation suggests MX_CLIPBOARD_CMD can be used to provide a custom clipboard command, but the implementation assumes the same command string is used for both copy (stdin) and paste (stdout). This makes it incompatible with standard asymmetric tools like xclip/wl-copy, rendering the feature unusable for its primary use case.
+
+# Evidence supporting the observation
+evidence:
+  - path: "README.md"
+    loc:
+      - "MX_CLIPBOARD_CMD"
+    note: "Documentation implies support for custom clipboard commands without noting symmetry constraint."
+  - path: "src/commands/clipboard.rs"
+    loc:
+      - "struct ClipboardCommand"
+      - "impl SystemClipboard"
+    note: "Implementation reuses the same command and arguments for both copy and paste operations."
+
+tags:
+  - "usability"
+  - "documentation"
+  - "config"

--- a/.jules/workstreams/generic/exchange/events/pending/project-root-detection.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/project-root-detection.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+# Metadata
+id: "ev2prj"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "consistency"
+confidence: "high"
+
+# Content
+title: "Project root detection assumes CWD is always root"
+statement: |
+  Documentation states that when mx runs outside of a project, placeholders stay untouched. However, the implementation simply uses the current working directory as the project root in all cases (except OS error), making the "outside project" behavior unreachable and causing placeholders to fail with "[mx missing]" instead of being ignored.
+
+# Evidence supporting the observation
+evidence:
+  - path: "README.md"
+    loc:
+      - "Project Root"
+    note: "Docs claim mx detects when it is outside a project and disables placeholder expansion."
+  - path: "src/commands/touch.rs"
+    loc:
+      - "fn find_project_root"
+    note: "Implementation returns current_dir() unconditionally."
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "fn expand_placeholders"
+    note: "Placeholder expansion only skips if root is None, which never happens."
+
+tags:
+  - "bug"
+  - "documentation"
+  - "logic"

--- a/.jules/workstreams/generic/workstations/consistency/histories/20260203-run001.yml
+++ b/.jules/workstreams/generic/workstations/consistency/histories/20260203-run001.yml
@@ -1,0 +1,36 @@
+schema_version: 1
+
+id: "run001"
+created_at: "2026-02-03T12:00:00Z"
+
+observer: consistency
+workstream: generic
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Initialize missing perspective.yml.
+  2. Analyze codebase for documentation drift.
+  3. Create events for found inconsistencies.
+  4. Update workstation state.
+
+actions:
+  - "Initialized perspective.yml"
+  - "Analyzed README.md vs src/ implementation"
+  - "Created event ev1clp for MX_CLIPBOARD_CMD asymmetry"
+  - "Created event ev2prj for Project Root detection logic"
+
+outcomes:
+  summary: "Identified 2 inconsistencies regarding clipboard config and project root detection."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/clipboard-asymmetry.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/project-root-detection.yml"
+  notes: |
+    Found that MX_CLIPBOARD_CMD implementation is symmetric (broken for most tools) contrary to docs implication.
+    Found that project root detection is effectively non-existent (always CWD), contradicting docs about "outside project" behavior.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/consistency/perspective.yml
+++ b/.jules/workstreams/generic/workstations/consistency/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: consistency
+workstream: generic
+
+updated_at: "2026-02-03T12:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-03T12:00:00Z"
+    summary: "Identified 2 inconsistencies regarding clipboard config and project root detection."
+    history_path: ".jules/workstreams/generic/workstations/consistency/histories/20260203-run001.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Executed consistency observer workflow. Identified and recorded two documentation drifts regarding clipboard configuration and project root detection. Updated workstation state.

---
*PR created automatically by Jules for task [12545757804395166608](https://jules.google.com/task/12545757804395166608) started by @akitorahayashi*