### PR TITLE
Taxonomy Observation Run

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/ambiguous-term-key.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/ambiguous-term-key.yml
@@ -1,0 +1,29 @@
+schema_version: 1
+
+# Metadata
+id: "e1j3n6"
+issue_id: ""
+created_at: "2024-05-21"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Ambiguous Term 'Key'"
+statement: |
+  The term "Key" is used for both "snippet name/path" (in `storage.rs` and `list_snippets.rs`) and "context file alias/path" (in `touch.rs`, `cat.rs`). These are distinct domains (global snippets vs local context) but share the same generic name.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/storage.rs"
+    loc:
+      - "SnippetFile.key"
+    note: "Refers to a global snippet identifier."
+  - path: "src/commands/touch.rs"
+    loc:
+      - "touch(..., key: &str, ...)"
+    note: "Refers to a local context file alias or path."
+
+tags:
+  - "naming"
+  - "ambiguity"
+  - "domain-language"

--- a/.jules/workstreams/generic/exchange/events/pending/inconsistent-arg-naming.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/inconsistent-arg-naming.yml
@@ -1,0 +1,36 @@
+schema_version: 1
+
+# Metadata
+id: "b8g0k3"
+issue_id: ""
+created_at: "2024-05-21"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Inconsistent Argument Naming for File Identifiers"
+statement: |
+  The concept of a file identifier is named `key` in `touch`, `cat`, `clean`, and `list` return types, but `snippet` in `main.rs` for the copy command, and `query` in `lib.rs` and `copy_snippet.rs`.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/main.rs"
+    loc:
+      - "Commands::Touch { key, .. }"
+      - "Commands::Command { snippet }"
+    note: "CLI arguments use different names for the same identifier concept."
+  - path: "src/lib.rs"
+    loc:
+      - "touch_context(key: &str, ...)"
+      - "copy_snippet(query: &str, ...)"
+    note: "Library functions use `key` vs `query`."
+  - path: "src/storage.rs"
+    loc:
+      - "resolve_snippet(raw_query: &str)"
+      - "SnippetFile.key"
+    note: "Storage uses `raw_query` for input but `key` for the struct field."
+
+tags:
+  - "naming"
+  - "inconsistency"
+  - "arguments"

--- a/.jules/workstreams/generic/exchange/events/pending/inconsistent-cli-verb-copy.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/inconsistent-cli-verb-copy.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+# Metadata
+id: "a7f9j2"
+issue_id: ""
+created_at: "2024-05-21"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Inconsistent CLI Verb for Copying Snippets"
+statement: |
+  The CLI subcommand `command` (alias `c`) is used to copy snippets, but the internal logic is `copy_snippet` and the domain is "snippet copying". "Command" is ambiguous and generic.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/main.rs"
+    loc:
+      - "Commands::Command"
+      - "handle_command"
+    note: "CLI defines `Command` enum variant and `handle_command` function."
+  - path: "src/lib.rs"
+    loc:
+      - "copy_snippet"
+    note: "Library exposes `copy_snippet` function."
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "CopySnippet"
+    note: "Internal implementation is named `CopySnippet`."
+
+tags:
+  - "cli"
+  - "naming"
+  - "inconsistency"

--- a/.jules/workstreams/generic/exchange/events/pending/inconsistent-module-naming.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/inconsistent-module-naming.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+# Metadata
+id: "c9h1l4"
+issue_id: ""
+created_at: "2024-05-21"
+author_role: "taxonomy"
+confidence: "medium"
+
+# Content
+title: "Inconsistent Module Naming (Plurality)"
+statement: |
+  `src/commands/copy_snippet.rs` uses singular naming, while `src/commands/list_snippets.rs` uses plural naming. Other modules (`cat.rs`, `touch.rs`) use verbs.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "mod copy_snippet"
+    note: "Singular 'snippet' in filename."
+  - path: "src/commands/list_snippets.rs"
+    loc:
+      - "mod list_snippets"
+    note: "Plural 'snippets' in filename."
+  - path: "src/commands/touch.rs"
+    loc:
+      - "mod touch"
+    note: "Verb only, no object."
+
+tags:
+  - "naming"
+  - "inconsistency"
+  - "modules"

--- a/.jules/workstreams/generic/exchange/events/pending/redundant-outcome-types.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/redundant-outcome-types.yml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+# Metadata
+id: "d0i2m5"
+issue_id: ""
+created_at: "2024-05-21"
+author_role: "taxonomy"
+confidence: "medium"
+
+# Content
+title: "Redundant Outcome Types"
+statement: |
+  `SnippetFile` (in `storage.rs`) and `CopyOutcome` (in `copy_snippet.rs`) share similar structures (key, relative path, absolute path). `ListEntry` is also similar but adds metadata.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/storage.rs"
+    loc:
+      - "struct SnippetFile"
+    note: "Defines key, relative_path, absolute_path."
+  - path: "src/commands/copy_snippet.rs"
+    loc:
+      - "struct CopyOutcome"
+    note: "Defines key, relative_path, absolute_path (identical structure)."
+  - path: "src/commands/list_snippets.rs"
+    loc:
+      - "struct ListEntry"
+    note: "Defines key, relative_path, title, description."
+
+tags:
+  - "data-model"
+  - "redundancy"

--- a/.jules/workstreams/generic/workstations/taxonomy/histories/20240521-f2k4o7.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/histories/20240521-f2k4o7.yml
@@ -1,0 +1,49 @@
+schema_version: 1
+
+id: "f2k4o7"
+created_at: "2024-05-21T12:00:00Z"
+
+observer: "taxonomy"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Emit Event: Inconsistent CLI Verb for Copying Snippets
+  2. Emit Event: Inconsistent Argument Naming for File Identifiers
+  3. Emit Event: Inconsistent Module Naming
+  4. Emit Event: Redundant Outcome Types
+  5. Emit Event: Ambiguous Term "Key"
+  6. Verify Events
+  7. Complete pre commit steps
+  8. Workstation Maintenance
+
+actions:
+  - type: "create_file"
+    path: ".jules/workstreams/generic/exchange/events/pending/inconsistent-cli-verb-copy.yml"
+  - type: "create_file"
+    path: ".jules/workstreams/generic/exchange/events/pending/inconsistent-arg-naming.yml"
+  - type: "create_file"
+    path: ".jules/workstreams/generic/exchange/events/pending/inconsistent-module-naming.yml"
+  - type: "create_file"
+    path: ".jules/workstreams/generic/exchange/events/pending/redundant-outcome-types.yml"
+  - type: "create_file"
+    path: ".jules/workstreams/generic/exchange/events/pending/ambiguous-term-key.yml"
+
+outcomes:
+  summary: "Identified 5 taxonomy inconsistencies in naming, CLI verbs, and module structure."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/inconsistent-cli-verb-copy.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/inconsistent-arg-naming.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/inconsistent-module-naming.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/redundant-outcome-types.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/ambiguous-term-key.yml"
+  notes: |
+    Found significant inconsistencies in how snippets are handled vs how they are exposed in CLI.
+    The term "Key" is overloaded.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "taxonomy"
+workstream: "generic"
+
+updated_at: "2024-05-21T12:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2024-05-21T12:00:00Z"
+    summary: "Identified 5 taxonomy inconsistencies in naming, CLI verbs, and module structure."
+    history_path: ".jules/workstreams/generic/workstations/taxonomy/histories/20240521-f2k4o7.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Ran the taxonomy observer role. Identified 5 naming inconsistencies and emitted corresponding events. Created initial workstation history and perspective files.

---
*PR created automatically by Jules for task [9222320365425809997](https://jules.google.com/task/9222320365425809997) started by @akitorahayashi*