### PR TITLE
docs: emit librarian events for documentation architecture

### DIFF
--- a/.jules/exchange/events/missing-docs-directory-librarian.md
+++ b/.jules/exchange/events/missing-docs-directory-librarian.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-01"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Statement
+
+The repository lacks a dedicated `docs/` structural foundation for documentation, forcing specialized human-facing documentation content into the root namespace (primarily `README.md`) and increasing navigation entropy. A `docs/` directory needs to be scaffolded to house specialized topics like CLI usage, configuration, and development guides.
+
+## Evidence
+
+- path: "."
+  loc: "root directory"
+  note: "No `docs/` directory exists. This violates the principle that 'If no structural foundation exists, architect and scaffold it from scratch rather than forcing content into unrelated files.' and that root namespace is scarce."

--- a/.jules/exchange/events/readme-mixed-responsibilities-librarian.md
+++ b/.jules/exchange/events/readme-mixed-responsibilities-librarian.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-01"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Statement
+
+The root `README.md` suffers from mixed responsibilities. Instead of remaining purely map-level orientation (entry point), it acts as a catch-all document, aggregating CLI usage, detailed context alias tables, dynamic pathing rules, and the complete development guide. This flat accumulation hides structural intent and makes lookup branching inefficient. The file should be split into distinct canonical paths such as `docs/cli.md`, `docs/configuration.md`, and `docs/development.md`.
+
+## Evidence
+
+- path: "README.md"
+  loc: "Lines 16-86"
+  note: "Contains detailed CLI usage instructions and extensive reference tables for context management aliases and template placeholders, which should be in a separate specification or procedure document."
+- path: "README.md"
+  loc: "Lines 125-147"
+  note: "Contains the complete development guide including commands, testing culture, and internal testing structural patterns, conflating the external user's entry point with the internal developer's procedural guidelines."


### PR DESCRIPTION
This pull request emits two high-signal events from the perspective of the `librarian` observer role.

1.  **`missing-docs-directory-librarian.md`**: Identifies the lack of a structural foundation (`docs/` directory) for specialized human-facing documentation, which violates structural principles and forces content into the root namespace.
2.  **`readme-mixed-responsibilities-librarian.md`**: Identifies that `README.md` suffers from mixed responsibilities (acting as a catch-all for CLI usage, reference tables, and development guides) rather than acting purely as an orientation map-level entry point.

These events provide evidence-backed findings to improve the repository's documentation information architecture and routing clarity, keeping the root namespace reserved for cross-cutting entry points. No files outside of `.jules/` were modified.

---
*PR created automatically by Jules for task [14298677617400310804](https://jules.google.com/task/14298677617400310804) started by @akitorahayashi*