### PR TITLE
chore(taxonomy): add taxonomy observer events for naming inconsistencies

### DIFF
--- a/.jules/exchange/events/key-vs-alias-taxonomy.md
+++ b/.jules/exchange/events/key-vs-alias-taxonomy.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-05-24"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The identifier used to resolve a context file path is referred to as both a "key" and an "alias" without a clear distinction or formal glossary. The CLI uses `<key>` (e.g., `mx touch <key>`), and the code has `src/domain/context_file/key.rs` to handle these. However, the hardcoded dictionary of identifiers is defined in an `alias_registry.rs` and the user documentation explicitly refers to them as "Context Management Keys (Aliases)". This violates the "One Concept, One Preferred Term" principle.
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "Touch { key: String }, Cat { key: String }"
+  note: "CLI arguments use 'key' to refer to the context file identifier."
+- path: "src/domain/context_file/alias_registry.rs"
+  loc: "resolve_alias(key: &str)"
+  note: "The internal registry and lookup function uses the term 'alias' instead of 'key'."
+- path: "README.md"
+  loc: "Context Management Keys (Aliases)"
+  note: "Documentation conflates the two terms without establishing a canonical one."

--- a/.jules/exchange/events/snippet-vs-command-taxonomy.md
+++ b/.jules/exchange/events/snippet-vs-command-taxonomy.md
@@ -1,0 +1,24 @@
+---
+created_at: "2024-05-24"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The domain concept of a reusable text fragment is referred to inconsistently across the system's boundaries. Internally, the domain and types consistently use "Snippet" (e.g., `SnippetEntry`, `SnippetCatalog`, `SnippetStore`, `add_snippet`). Externally, the CLI, environment variables, and filesystem layout use "Command" (e.g., `mx command <snippet>`, `create-command`, `MX_COMMANDS_ROOT`, `~/.config/mx/commands/`). This dual vocabulary creates confusion between the domain boundary and user-facing boundary, and violates the "One Concept, One Preferred Term" and "Naming shape consistency across boundaries" principles.
+
+## Evidence
+
+- path: "src/domain/snippet/catalog_entry.rs"
+  loc: "SnippetEntry"
+  note: "Domain uses 'Snippet' as the canonical type name."
+- path: "src/app/cli/mod.rs"
+  loc: "CreateCommand vs Add { path, title... }, Copy { snippet }"
+  note: "CLI mixes 'snippet' argument names with 'create_command' action, and uses `mx command <snippet>`."
+- path: "README.md"
+  loc: "Storage layout: `~/.config/mx/commands/`"
+  note: "Filesystem uses 'commands' to store what the domain calls 'snippets'."
+- path: "README.md"
+  loc: "`MX_COMMANDS_ROOT`"
+  note: "Environment variables use the term 'commands'."


### PR DESCRIPTION
Added two taxonomy observer events:
1. `snippet-vs-command-taxonomy.md`: Documented the inconsistency between the domain's use of "Snippet" and the CLI's use of "Command".
2. `key-vs-alias-taxonomy.md`: Documented the conflation of the terms "key" and "alias" in resolving context file paths.

---
*PR created automatically by Jules for task [1486528822546570902](https://jules.google.com/task/1486528822546570902) started by @akitorahayashi*