### PR TITLE
Emit coverage risk events for untested adapters

### DIFF
--- a/.jules/exchange/events/filesystem-snippet-store-uncovered-cov.md
+++ b/.jules/exchange/events/filesystem-snippet-store-uncovered-cov.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-01"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+The `FilesystemSnippetStore` adapter is not fully covered by tests, resulting in potential untested code paths for snippet persistence and removal operations.
+
+## Evidence
+
+- path: "src/adapters/snippet_store/filesystem_store.rs"
+  loc: "31/44 lines covered"
+  note: "Coverage reports indicate that `FilesystemSnippetStore` has 31/44 lines covered. This suggests that error scenarios or specific branches, particularly related to directory cleanup up to `commands_root` upon snippet removal or handling missing environment variables, might lack test validation."

--- a/.jules/exchange/events/local-context-store-uncovered-cov.md
+++ b/.jules/exchange/events/local-context-store-uncovered-cov.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-01"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+Critical file operations and cleanup paths in `LocalContextFileStore` are lacking test coverage, particularly around the creation, reading, and deletion of context files and workspace boundaries.
+
+## Evidence
+
+- path: "src/adapters/context_file_store/local_context_store.rs"
+  loc: "50/67 lines covered"
+  note: "Coverage report shows only 50/67 lines covered. Specifically, paths dealing with `read_context_contents` error handling, `remove_context_root` successful and failed cleanups, and `remove_context_file` directory climbing are missing coverage. These are important side-effects that determine whether `.mx/` state accurately tracks the snippet system or leaves dangling artifacts or incorrect reads."

--- a/.jules/exchange/events/system-clipboard-uncovered-cov.md
+++ b/.jules/exchange/events/system-clipboard-uncovered-cov.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-01"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+The `SystemClipboard` adapter logic is completely uncovered by tests, representing a major blind spot for a core integration path across multiple OS platforms.
+
+## Evidence
+
+- path: "src/adapters/clipboard/system_clipboard.rs"
+  loc: "0/93 lines covered"
+  note: "Coverage report shows 0/93 lines covered for this module. The `SystemClipboard::detect`, `Clipboard::copy`, and `Clipboard::paste` functions are completely untested, meaning that failures in reading environment variables, identifying platform commands (like `pbcopy`/`pbpaste`, `wl-copy`/`xclip`, `clip`/`powershell`), or actual OS process spawning will only be discovered in production."


### PR DESCRIPTION
This PR contains observer events emitted under the `cov` role.

The events document three major test coverage gaps identified in critical path adapters:

1.  **SystemClipboard (0% coverage):** Lack of test coverage for platform-specific command spawning (pbcopy, xclip, wl-copy, powershell) and environment variable reading.
2.  **LocalContextFileStore (50/67 lines covered):** Lack of coverage for critical file system operations, particularly around `read_context_contents` error handling and cleanup paths in `remove_context_file` and `remove_context_root`.
3.  **FilesystemSnippetStore (31/44 lines covered):** Lack of coverage for error handling and parent directory cleanup during snippet removal operations.

---
*PR created automatically by Jules for task [3276463224810137239](https://jules.google.com/task/3276463224810137239) started by @akitorahayashi*