### PR TITLE
Add rustacean observer events

### DIFF
--- a/.jules/exchange/events/excessive-dynamic-dispatch-rustacean.md
+++ b/.jules/exchange/events/excessive-dynamic-dispatch-rustacean.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-01"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The application extensively uses dynamic dispatch (`&dyn Trait`) in core logic functions (`app/commands/`), imposing potential runtime overhead instead of relying on monomorphized static dispatch (`impl Trait`) where it would be sufficient and potentially more performant, given that most commands operate with specific static combinations of struct dependencies.
+
+## Evidence
+
+- path: "src/app/commands/copy/mod.rs"
+  loc: "17-20"
+  note: "Arguments `catalog`, `clipboard`, and `workspace_store` use `&dyn SnippetCatalog`, `&dyn Clipboard`, and `Option<&dyn ContextFileStore>` respectively, rather than statically typed generic bounds."
+- path: "src/app/api.rs"
+  loc: "35-42"
+  note: "The API explicitly coerces `&LocalContextFileStore` into `&dyn ContextFileStore` to pass it down to `commands::copy::execute`. Similar coercions occur throughout `src/app/api.rs` when wrapping core logic."

--- a/.jules/exchange/events/stringly-typed-errors-rustacean.md
+++ b/.jules/exchange/events/stringly-typed-errors-rustacean.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-01"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The application propagates errors as transparent `std::io::Error` or stringly-typed variants, potentially losing semantic domain context. For instance, file operations fail with generic `std::io::Error` instead of custom context-rich errors that clarify *why* the read or write occurred. The `AppError` enum is flat and does not maintain an error boundary or domain hierarchy.
+
+## Evidence
+
+- path: "src/domain/error.rs"
+  loc: "4-18"
+  note: "The AppError enum mixes low-level I/O errors (via #[from] io::Error) and string-based domain errors (ConfigError, NotFound, etc.). This makes it difficult to reason about the exact source or recovery of an error without parsing strings."
+- path: "src/app/api.rs"
+  loc: "23-26"
+  note: "Public API functions return `AppError` directly, exposing stringly typed error variants to callers rather than structured data."

--- a/.jules/exchange/events/unnecessary-clone-clipboard-rustacean.md
+++ b/.jules/exchange/events/unnecessary-clone-clipboard-rustacean.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-01"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The `SystemClipboard` struct clones `ClipboardCommand` unnecessarily during structural assembly in `detect()`, which could be optimized. The `ClipboardCommand` instances only hold `String` allocations, making clones slightly expensive but mostly just noisy for what could be done with moves.
+
+## Evidence
+
+- path: "src/adapters/clipboard/system_clipboard.rs"
+  loc: "58-63"
+  note: "Clones `command` twice (explicit `.clone()` and implicit copy of String via move if one wasn't a clone) just to set `copy_command` and `paste_command` to the same configured fallback command. This could be simplified by creating distinct commands or implementing a cleaner fallback mechanism."


### PR DESCRIPTION
This commit adds three event files in `.jules/exchange/events/` acting as the `rustacean` observer.
These events highlight areas of improvement in the Rust codebase related to:
- Excessive dynamic dispatch (`&dyn Trait`) in core logic functions.
- The `AppError` enum being stringly-typed and losing semantic domain context.
- Unnecessary clones of `String` during structural assembly in `SystemClipboard`.

---
*PR created automatically by Jules for task [17869378580250350342](https://jules.google.com/task/17869378580250350342) started by @akitorahayashi*