### PR TITLE
Emit high-signal events for CLI sentinel findings

### DIFF
--- a/.jules/exchange/events/io-separation-warning-stdout-cli-sentinel.md
+++ b/.jules/exchange/events/io-separation-warning-stdout-cli-sentinel.md
@@ -1,0 +1,15 @@
+---
+created_at: "2025-03-01"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Statement
+
+Diagnostic and warning messages are being printed to standard output (`stdout`) rather than standard error (`stderr`), violating I/O separation principles and potentially breaking automation when standard output is piped.
+
+## Evidence
+
+- path: "src/app/cli/touch.rs"
+  loc: "line 8"
+  note: "The warning message '⚠️ Context file already exists: ...' is emitted using `println!` (stdout) instead of `eprintln!` (stderr)."

--- a/.jules/exchange/events/missing-destructive-safety-cli-sentinel.md
+++ b/.jules/exchange/events/missing-destructive-safety-cli-sentinel.md
@@ -1,0 +1,21 @@
+---
+created_at: "2025-03-01"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Statement
+
+Destructive CLI commands lack uniform safety contracts, such as confirmation prompts or explicit override flags (e.g., `--force`), increasing the risk of operational accidents.
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "Commands enum"
+  note: "The `Clean` and `Remove` subcommands, which perform deletion, do not require a `--force` flag or equivalent explicit opt-in, unlike `Touch` and `CreateCommand` which include `--force` for overwriting."
+- path: "src/app/commands/clean/mod.rs"
+  loc: "execute function"
+  note: "Deletes the `.mx` directory or specified context files directly without dry-run or confirmation."
+- path: "src/app/commands/remove/mod.rs"
+  loc: "execute function"
+  note: "Deletes snippet files directly from the snippet store without explicit user confirmation."

--- a/.jules/exchange/events/naming-inconsistency-synonyms-cli-sentinel.md
+++ b/.jules/exchange/events/naming-inconsistency-synonyms-cli-sentinel.md
@@ -1,0 +1,21 @@
+---
+created_at: "2025-03-01"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Statement
+
+The CLI design introduces naming synonyms for the same conceptual action (deletion) and exhibits structural drift between documented commands and implementation.
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "Commands enum"
+  note: "The CLI uses two different verbs, `Clean` and `Remove`, for file deletion actions (deleting context files vs. snippet files). This violates the principle of avoiding synonyms."
+- path: "README.md"
+  loc: "CLI usage section"
+  note: "The documentation explicitly references `mx command wc` to copy a snippet, but the CLI implementation uses `copy` (with alias `c`), leading to an 'unrecognized subcommand' error when the user types `mx command`."
+- path: "src/app/cli/mod.rs"
+  loc: "Commands enum"
+  note: "The implemented subcommand is `Copy`, which does not have a `command` alias, confirming the structural drift from the README."


### PR DESCRIPTION
This pull request emits three event files in `.jules/exchange/events/` from the `cli_sentinel` observer role:
1. `missing-destructive-safety-cli-sentinel.md`: Flags the lack of explicit override or confirmation in `Clean` and `Remove` subcommands.
2. `io-separation-warning-stdout-cli-sentinel.md`: Flags the I/O violation where warnings are printed to `stdout` instead of `stderr` in `touch.rs`.
3. `naming-inconsistency-synonyms-cli-sentinel.md`: Flags naming synonyms (`Clean` vs `Remove`) and a structural drift between the README and the actual CLI implementation (e.g., `copy` alias).

These events provide evidence-backed findings to improve the CLI design and maintain operational contracts.

---
*PR created automatically by Jules for task [1139715117622515148](https://jules.google.com/task/1139715117622515148) started by @akitorahayashi*