### PR TITLE
docs: Emit observer events for structural architecture findings

### DIFF
--- a/.jules/exchange/events/excessive-public-surface-structural-arch.md
+++ b/.jules/exchange/events/excessive-public-surface-structural-arch.md
@@ -1,0 +1,15 @@
+---
+created_at: "2024-05-24"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Statement
+
+The internal architecture (such as `adapters` and `domain` modules) is publicly exported from the root library file, unnecessarily exposing implementation details. This expands the public surface area, making refactoring internal boundaries riskier due to potential downstream dependencies.
+
+## Evidence
+
+- path: "src/lib.rs"
+  loc: "lines 1-3"
+  note: "Publicly exports `pub mod adapters;` and `pub mod domain;`, exposing the internal repository structure to potential API consumers instead of providing a controlled facade."

--- a/.jules/exchange/events/hardcoded-adapters-api-structural-arch.md
+++ b/.jules/exchange/events/hardcoded-adapters-api-structural-arch.md
@@ -1,0 +1,18 @@
+---
+created_at: "2024-05-24"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Statement
+
+The API layer functions act as an orchestration point but inconsistently mix adapter instantiation with dependency injection. Hardcoding adapters (e.g., `LocalContextFileStore`, `SymlinkCheckout`) ties the API facade to specific infrastructure instead of remaining agnostic.
+
+## Evidence
+
+- path: "src/app/api.rs"
+  loc: "lines 22, 27, 43"
+  note: "Directly instantiates `LocalContextFileStore::new(find_workspace_root()?)`, hardwiring local filesystem assumptions."
+- path: "src/app/api.rs"
+  loc: "line 53"
+  note: "Directly instantiates `SymlinkCheckout::new()`, coupling the checkout workflow specifically to a symlink strategy instead of accepting the `SnippetCheckout` port."

--- a/.jules/exchange/events/horizontal-slicing-commands-structural-arch.md
+++ b/.jules/exchange/events/horizontal-slicing-commands-structural-arch.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-05-24"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Statement
+
+The CLI commands are organized by horizontal layers (`src/app/cli/` for argument parsing and `src/app/commands/` for execution logic) rather than by vertical slices. This violates the "Cohesion by change reason" principle, forcing scattered edits across multiple files and directories to implement or modify a single feature.
+
+## Evidence
+
+- path: "src/app/cli/"
+  loc: "Entire directory"
+  note: "Contains CLI-specific logic (e.g., `add.rs`, `checkout.rs`) that is coupled to the corresponding command implementations, requiring changes here for any new feature."
+- path: "src/app/commands/"
+  loc: "Entire directory"
+  note: "Contains the execution logic for each command (e.g., `add/mod.rs`, `checkout/mod.rs`), forcing developers to navigate between `src/app/cli/` and `src/app/commands/` to understand a single feature's flow."
+- path: "src/app/cli/mod.rs"
+  loc: "line 43"
+  note: "The match statement directly maps CLI variants to the `src/app/commands/` logic, further cementing the horizontal split."


### PR DESCRIPTION
Added three observer events for `structural_arch` highlighting horizontal slicing, excessive public surface area, and hardcoded infrastructure adapters.

---
*PR created automatically by Jules for task [6680825159342954029](https://jules.google.com/task/6680825159342954029) started by @akitorahayashi*