### PR TITLE
test: emit qa observer events

### DIFF
--- a/.jules/exchange/events/cli-integration-tests-redundancy-qa.md
+++ b/.jules/exchange/events/cli-integration-tests-redundancy-qa.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-01"
+author_role: "qa"
+confidence: "medium"
+---
+
+## Statement
+
+The integration tests for the CLI subcommands (`add.rs`, `cat.rs`, `clean.rs`, `copy.rs`, `create_command.rs`, `remove.rs`, `touch.rs`, `checkout.rs`, `list.rs`) test multiple overlapping paths that are already unit-tested at the `app::commands` boundary. E.g., `tests/cli/copy.rs` verifies that a missing snippet prints a failure, which is also unit-tested in `src/app/commands/copy/mod.rs`. Shifting these to pure unit tests for logic, and leaving CLI tests to focus strictly on arg parsing and adapter plumbing, could improve feedback speed.
+
+## Evidence
+
+- path: "tests/cli/copy.rs"
+  loc: "25-36"
+  note: "Tests the `unknown` snippet failure, duplicating `execute_surfaces_missing_snippet_errors` in `src/app/commands/copy/mod.rs`."
+- path: "tests/cli/create_command.rs"
+  loc: "47-55"
+  note: "Tests path boundary rejection `.mx/commands/` which is identically tested in `src/app/commands/create_command/mod.rs` at line 100."

--- a/.jules/exchange/events/file-clipboard-edge-cases-qa.md
+++ b/.jules/exchange/events/file-clipboard-edge-cases-qa.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-01"
+author_role: "qa"
+confidence: "high"
+---
+
+## Statement
+
+The `FileClipboard` adapter tests only verify the happy path for roundtrip copy and paste. They do not verify behavior when pasting from an empty or non-existent file, which could be an issue since it interacts directly with the filesystem (I/O). Testing failure diagnosability here ensures fallback errors are clear.
+
+## Evidence
+
+- path: "src/adapters/clipboard/file_clipboard.rs"
+  loc: "33-45"
+  note: "Only a single test `file_clipboard_roundtrip` exists. Lacks assertions for reading an uninitialized file or writing to an invalid path."

--- a/.jules/exchange/events/symlink-checkout-diagnosability-qa.md
+++ b/.jules/exchange/events/symlink-checkout-diagnosability-qa.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-01"
+author_role: "qa"
+confidence: "high"
+---
+
+## Statement
+
+The `SymlinkCheckout` adapter's test suite lacks an explicit test for the boundary case where the destination exists and is a regular file (not a symlink), which can cause the underlying `symlink` operation to fail without a clear diagnostic message for the user. Checking this behavior specifically would improve diagnosability.
+
+## Evidence
+
+- path: "src/adapters/snippet_checkout/symlink_checkout.rs"
+  loc: "42-93"
+  note: "Tests `creates_symlink_in_target_root` and `skips_existing_symlink` are present, but no test covers the error path when `target_path` exists as a normal file, which is an important boundary condition for filesystem interactions."


### PR DESCRIPTION
Add observer events identifying test quality findings based on the QA observer profile.

These events cover:
1.  **Redundancy**: Testing identical behavior (like missing snippet errors) in both `src/app/commands` and `tests/cli/`.
2.  **Edge Cases**: `FileClipboard` only testing happy-path roundtrips and not invalid paths.
3.  **Failure Diagnosability**: `SymlinkCheckout` lacking boundary tests for a regular file existing at the destination path instead of a symlink.

---
*PR created automatically by Jules for task [15011734187859820653](https://jules.google.com/task/15011734187859820653) started by @akitorahayashi*