### PR TITLE
docs: emit tactician observer events for AGENTS.md

### DIFF
--- a/.jules/exchange/events/volatile-cli-commands-tactician.md
+++ b/.jules/exchange/events/volatile-cli-commands-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2024-05-24"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The "Key Commands" section in `AGENTS.md` violates volatility control by listing detailed CLI commands, aliases, and flags (e.g., `mx copy <snippet>`, `-a`, `--force`), which are ephemeral operational details better discovered via CLI help (`--help`) or examining the code directly.
+
+## Evidence
+
+- path: "AGENTS.md"
+  loc: "38-58"
+  note: "Lists volatile specific usage parameters and flags for commands instead of focusing on strict scoped rules."

--- a/.jules/exchange/events/volatile-tech-stack-tactician.md
+++ b/.jules/exchange/events/volatile-tech-stack-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2024-05-24"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The "Tech Stack" section in `AGENTS.md` violates volatility control by restating volatile dependency details (e.g., `clap`, `serde`, `walkdir`, `assert_cmd`) that are authoritatively defined in `Cargo.toml`. These implementation details should be excluded unless they are execution-critical context for the agent.
+
+## Evidence
+
+- path: "AGENTS.md"
+  loc: "26-36"
+  note: "Restates core and testing libraries and their uses which change frequently and are managed by cargo."


### PR DESCRIPTION
This submission addresses the task of emitting high-signal findings as a `tactician` observer. 

Two events were created in `.jules/exchange/events/`:
1.  **volatile-tech-stack-tactician.md**: Identified that the "Tech Stack" section in `AGENTS.md` restates volatile dependency details that are authoritatively defined in `Cargo.toml`.
2.  **volatile-cli-commands-tactician.md**: Identified that the "Key Commands" section in `AGENTS.md` lists ephemeral operational details (detailed CLI commands, aliases, flags) which are better discovered via CLI help or code.

These files strictly adhere to the provided schema and role constraints. A previously drafted global-architectural-rules event was removed to comply with the user's explicit prohibition regarding the root `AGENTS.md` file constraints.

---
*PR created automatically by Jules for task [4613911194888984035](https://jules.google.com/task/4613911194888984035) started by @akitorahayashi*