### PR TITLE
docs: remove volatile information from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,52 +25,22 @@ Snippets are stored as Markdown files under `~/.config/mx/commands/`. Metadata (
 
 ## Tech Stack
 
-- **Language**: Rust
-- **Core Libraries**:
-    - `clap`: For command-line argument parsing.
-    - `serde` (`serde_yaml`, `serde_json`): For serialization and deserialization of data.
-    - `walkdir`: For directory traversal.
-- **Testing Libraries**:
-    - `assert_cmd`, `predicates`: For CLI integration testing.
-    - `serial_test`: For running tests serially.
-    - `tempfile`: For creating temporary files and directories in tests.
+- Language: Rust
 
 ## Key Commands
 
-- **Run Application**:
-    - `mx list`: List all available snippets with title/description from front matter.
-    - `mx copy <snippet>` / `mx c <snippet>`: Copy a snippet to the clipboard, stripping front matter.
-    - `mx touch <key>` / `mx t <key>`: Create context files in `.mx/` directory with clipboard content.
-        - Supports predefined aliases (e.g., aif, atk, df, er, if, is, pdr, pdt, pl, rf, rp, rq, rv, tk, tko, wn)
-        - Supports dynamic paths with auto `.md` extension and directory creation
-        - Example: `mx t docs/spec` creates `.mx/docs/spec.md` with clipboard content
-    - `mx cat <key>` / `mx ct <key>`: Display the contents of context files from `.mx/` directory.
-        - Uses the same path resolution as `touch` (aliases, dynamic paths, etc.)
-        - Example: `mx ct tk` displays contents of `.mx/tasks.md`
-    - `mx checkout <snippet>` / `mx co <snippet>`: Create a symlink in `.mx/commands/` pointing to the snippet in `~/.config/mx/commands/`.
-        - `mx checkout -a` / `mx checkout --all`: Symlink all snippets from the global catalog into `.mx/commands/`.
-        - `.mx/commands/.gitignore` (content: `*`) is created automatically to prevent committing symlinks.
-    - `mx add <path>` / `mx a <path>`: Save clipboard contents as a snippet. Path must be under `.mx/commands/`.
-        - `--title`, `--description`: Embed front matter in the saved file.
-        - `--force`: Overwrite an existing snippet.
-    - `mx remove <snippet>` / `mx rm <snippet>`: Delete a snippet from `~/.config/mx/commands/`.
-    - `mx create-command <path>` / `mx cc <path>`: Create a new snippet file at `<path>` (under `.mx/commands/`) pre-populated with a front matter template embedded in the binary.
-        - `--force`: Overwrite an existing file.
-- **Linting**:
-    - `cargo fmt --check`: Check code formatting.
-    - `cargo clippy --all-targets --all-features -- -D warnings`: Run the linter and check for warnings.
-- **Testing**:
-    - `RUST_TEST_THREADS=1 cargo test --all-targets --all-features`: Run all tests.
+- Run Application: Detailed CLI usage and available commands are authoritatively documented in the `README.md`. At a high level, `mx` provides commands to list, copy, and manage snippets, as well as commands (`mx touch`, `mx cat`) to manage and view context files in project directories.
+- Linting & Testing: The project relies on standard cargo workflows (`cargo fmt`, `cargo clippy`, `cargo test`). Refer to `justfile` for typical task execution details.
 
 ## Testing Strategy
 
 The project has a comprehensive testing strategy:
-- **Framework**: Uses Rust's built-in testing framework.
-- **Location**:
+- Framework: Uses Rust's built-in testing framework.
+- Location:
     - Unit tests are located alongside the source code in the `src/` directory.
     - Integration tests are in the `tests/` directory, covering both the CLI and the library's public API.
-- **CI**: A GitHub Actions workflow (`run-tests.yml`) automatically runs all tests on macOS for every pull request and push to the main branch.
-- **Test Support**: A dedicated `src/testing/` module provides in-memory stubs for all ports (clipboard, context store, snippet catalog, snippet checkout, snippet store), ensuring tests are isolated and repeatable.
+- CI: A GitHub Actions workflow (`run-tests.yml`) automatically runs all tests on macOS for every pull request and push to the main branch.
+- Test Support: A dedicated `src/testing/` module provides in-memory stubs for all ports (clipboard, context store, snippet catalog, snippet checkout, snippet store), ensuring tests are isolated and repeatable.
 
 
 ## Development Guidelines


### PR DESCRIPTION
Update `AGENTS.md` to remove specific CLI commands, flags, aliases, and specific Cargo dependencies. This helps ensure that the document follows the project principles on volatility control, relying instead on authoritative sources like `README.md` and `justfile`. Also refactored formatting to adhere to style guidelines that avoid bold text (`**`).

---
*PR created automatically by Jules for task [5844358107425021235](https://jules.google.com/task/5844358107425021235) started by @akitorahayashi*