### PR TITLE
test: Add test coverage to FilesystemSnippetStore

### DIFF
--- a/src/adapters/snippet_store/filesystem_store.rs
+++ b/src/adapters/snippet_store/filesystem_store.rs
@@ -86,3 +86,130 @@ impl SnippetStore for FilesystemSnippetStore {
         Ok(target)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_remove_snippet_cleans_up_empty_directories() {
+        let dir = tempdir().unwrap();
+        let store = FilesystemSnippetStore::from_root(dir.path());
+
+        let snippet_path = PathBuf::from("a/b/c.md");
+        store.write_snippet(&snippet_path, "content").unwrap();
+
+        let removed_path = store.remove_snippet(&snippet_path).unwrap();
+        assert_eq!(removed_path, dir.path().join("commands").join("a/b/c.md"));
+
+        assert!(!removed_path.exists());
+        assert!(!dir.path().join("commands").join("a/b").exists());
+        assert!(!dir.path().join("commands").join("a").exists());
+        assert!(dir.path().join("commands").exists());
+    }
+
+    #[test]
+    fn test_remove_snippet_leaves_non_empty_directories() {
+        let dir = tempdir().unwrap();
+        let store = FilesystemSnippetStore::from_root(dir.path());
+
+        let snippet_path1 = PathBuf::from("a/b/c1.md");
+        let snippet_path2 = PathBuf::from("a/b/c2.md");
+        store.write_snippet(&snippet_path1, "content1").unwrap();
+        store.write_snippet(&snippet_path2, "content2").unwrap();
+
+        store.remove_snippet(&snippet_path1).unwrap();
+
+        assert!(!dir.path().join("commands").join("a/b/c1.md").exists());
+        assert!(dir.path().join("commands").join("a/b/c2.md").exists());
+        assert!(dir.path().join("commands").join("a/b").exists());
+        assert!(dir.path().join("commands").join("a").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_from_env_missing_home() {
+        // Save current environment variables to restore them later.
+        let old_mx_commands_root = env::var_os("MX_COMMANDS_ROOT");
+        let old_home = env::var_os("HOME");
+
+        env::remove_var("MX_COMMANDS_ROOT");
+        env::remove_var("HOME");
+
+        let result = FilesystemSnippetStore::from_env();
+
+        assert!(result.is_err());
+        if let Err(AppError::ConfigError(message)) = result {
+            assert_eq!(message, "HOME environment variable not set");
+        } else {
+            panic!("Expected AppError::ConfigError, got something else");
+        }
+
+        // Restore environment variables
+        if let Some(val) = old_mx_commands_root {
+            env::set_var("MX_COMMANDS_ROOT", val);
+        }
+        if let Some(val) = old_home {
+            env::set_var("HOME", val);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_from_env_with_mx_commands_root() {
+        let old_mx_commands_root = env::var_os("MX_COMMANDS_ROOT");
+
+        env::set_var("MX_COMMANDS_ROOT", "/custom/path");
+
+        let store = FilesystemSnippetStore::from_env().unwrap();
+        assert_eq!(store.commands_root, PathBuf::from("/custom/path"));
+
+        // Restore
+        if let Some(val) = old_mx_commands_root {
+            env::set_var("MX_COMMANDS_ROOT", val);
+        } else {
+            env::remove_var("MX_COMMANDS_ROOT");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_from_env_with_home() {
+        let old_mx_commands_root = env::var_os("MX_COMMANDS_ROOT");
+        let old_home = env::var_os("HOME");
+
+        env::remove_var("MX_COMMANDS_ROOT");
+        env::set_var("HOME", "/home/user");
+
+        let store = FilesystemSnippetStore::from_env().unwrap();
+        assert_eq!(store.commands_root, PathBuf::from("/home/user/.config/mx/commands"));
+
+        // Restore
+        if let Some(val) = old_mx_commands_root {
+            env::set_var("MX_COMMANDS_ROOT", val);
+        }
+        if let Some(val) = old_home {
+            env::set_var("HOME", val);
+        } else {
+            env::remove_var("HOME");
+        }
+    }
+
+    #[test]
+    fn test_remove_snippet_not_found() {
+        let dir = tempdir().unwrap();
+        let store = FilesystemSnippetStore::from_root(dir.path());
+
+        let snippet_path = PathBuf::from("nonexistent.md");
+        let result = store.remove_snippet(&snippet_path);
+
+        assert!(result.is_err());
+        if let Err(AppError::NotFound(message)) = result {
+            assert!(message.contains("Snippet file not found"));
+        } else {
+            panic!("Expected AppError::NotFound, got {:?}", result);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds test coverage to `FilesystemSnippetStore`. It specifically targets the scenarios mentioned in the plan:
- Directory cleanup up to `commands_root` upon snippet removal.
- Handling missing environment variables scenarios for `from_env`.

All tests pass successfully.

---
*PR created automatically by Jules for task [4456180346765182623](https://jules.google.com/task/4456180346765182623) started by @akitorahayashi*