### PR TITLE
feat: add taxonomy observer events for snippet naming consistency

### DIFF
--- a/.jules/exchange/events/snippet_reference_naming_taxonomy.md
+++ b/.jules/exchange/events/snippet_reference_naming_taxonomy.md
@@ -1,0 +1,44 @@
+---
+label: "refacts"
+created_at: "2024-03-30"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+Identifiers used to locate a given snippet (or command) are inconsistently named. `snippet`, `path`, `query`, and `key` are used across various API boundaries, CLI arguments, and internal methods to mean the same thing.
+
+## Goal
+
+Standardize the terminology for a snippet identifier to improve code readability and refactoring safety.
+
+## Context
+
+The system needs to identify snippets by some string (e.g., "w/wc"). The name of this string parameter changes depending on where you look in the code. Some commands use `snippet`, others use `path` (even though it's resolved via a query and isn't strictly an OS filesystem path from the user's perspective). The catalog adapter takes a `raw_query`, and the resulting struct has a `key` and a `relative_path`. Context files, on the other hand, strictly use `key`.
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "line 38"
+  note: "`mx copy` CLI command uses parameter name `snippet`."
+- path: "src/app/cli/mod.rs"
+  loc: "line 40"
+  note: "`mx checkout` CLI command uses parameter name `path`."
+- path: "src/app/api.rs"
+  loc: "line 56"
+  note: "`checkout_snippets` API method uses parameter name `query`."
+- path: "src/domain/ports/snippet_catalog.rs"
+  loc: "line 6"
+  note: "`resolve_snippet` uses `raw_query`."
+- path: "src/domain/snippet/catalog_entry.rs"
+  loc: "line 6"
+  note: "`SnippetEntry` differentiates between `key`, `relative_path`, and `absolute_path`."
+
+## Change Scope
+
+- `src/app/cli/`
+- `src/app/commands/`
+- `src/app/api.rs`
+- `src/domain/ports/snippet_catalog.rs`
+- `src/adapters/snippet_catalog/`

--- a/.jules/exchange/events/snippet_vs_command_taxonomy.md
+++ b/.jules/exchange/events/snippet_vs_command_taxonomy.md
@@ -1,0 +1,45 @@
+---
+label: "refacts"
+created_at: "2024-03-30"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The repository uses both "snippet" and "command" interchangeably to refer to the same underlying concept: a markdown file managed by the system and output to the clipboard or checked out as a symlink. This creates ambiguity.
+
+## Goal
+
+Establish one canonical term ("snippet" or "command") for this concept and rename files, directories, configuration keys, and APIs consistently.
+
+## Context
+
+The repository stores these items in `~/.config/mx/commands/` and checks them out into `.mx/commands/`. The CLI command is `mx create-command`. However, the internal domain types use `SnippetEntry`, `SnippetCatalog`, `SnippetStore`, and CLI arguments are often named `snippet`. The application's purpose as a "snippet" manager is explicitly referenced in the `mx` CLI about string ("Unified CLI for mx snippets") but the data is stored in a `commands/` directory.
+
+## Evidence
+
+- path: "src/domain/snippet/catalog_entry.rs"
+  loc: "struct SnippetEntry"
+  note: "Domain type uses 'Snippet'."
+- path: "src/app/cli/mod.rs"
+  loc: "line 59"
+  note: "CLI command is `CreateCommand` and its help text says 'Create a new command template in .mx/commands/'."
+- path: "src/adapters/snippet_catalog/filesystem_catalog.rs"
+  loc: "line 12"
+  note: "The variable is `commands_root` but it is within `FilesystemSnippetCatalog`."
+- path: "README.md"
+  loc: "line 5"
+  note: "Refers to 'Snippet command' and mentions 'any markdown snippet under ~/.config/mx/commands/'."
+
+## Change Scope
+
+- `src/domain/snippet/`
+- `src/domain/ports/`
+- `src/adapters/snippet_catalog/`
+- `src/adapters/snippet_store/`
+- `src/adapters/snippet_checkout/`
+- `src/app/cli/`
+- `src/app/commands/`
+- `src/app/api.rs`
+- `tests/snippets/`


### PR DESCRIPTION
Added two event files documenting taxonomy findings regarding inconsistent terminology ("snippet" vs "command") and identifier naming ("snippet", "path", "query", "key").

---
*PR created automatically by Jules for task [10592903183733414952](https://jules.google.com/task/10592903183733414952) started by @akitorahayashi*