### PR TITLE
Emit data architecture events for observer role

### DIFF
--- a/.jules/exchange/events/file_system_snippet_coupling_data_arch.md
+++ b/.jules/exchange/events/file_system_snippet_coupling_data_arch.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2024-03-30"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The core domain model for a snippet (`SnippetEntry`) has filesystem concepts leaked into it. It includes an `absolute_path`. Operations like `copy`, `list`, and `checkout` read directly from `absolute_path` inside the core domain layer.
+
+## Goal
+
+The core domain model should be sovereign and independent of the transport or persistence layer. File loading should be abstracted via a port (e.g., `SnippetStore`), and `SnippetEntry` shouldn't be concerned with filesystem paths unless that is explicitly part of the model's domain, but reading files directly from `absolute_path` is a leak.
+
+## Context
+
+A domain object representing a snippet shouldn't need a filesystem path to be parsed and manipulated. In fact, `catalog.resolve_snippet` returns `SnippetEntry`, and `execute` in the `copy`, `list`, and `checkout` modules reads `absolute_path` directly. This couples the core domain logic to the filesystem. The `SnippetStore` port should abstract this reading capability, returning the content directly, or `SnippetEntry` should contain the `content` (maybe lazily loaded, or loaded up-front).
+
+## Evidence
+
+- path: "src/domain/snippet/catalog_entry.rs"
+  loc: "line 6"
+  note: "`absolute_path` leaks filesystem details into the core domain."
+- path: "src/app/commands/copy/mod.rs"
+  loc: "line 21"
+  note: "Direct `fs::read_to_string` on `snippet_entry.absolute_path` bypasses any abstraction that `SnippetStore` or `SnippetCatalog` might have."
+- path: "src/app/commands/list/mod.rs"
+  loc: "line 19"
+  note: "Directly uses `fs::read_to_string` instead of using a port."
+
+## Change Scope
+
+- `src/domain/snippet/catalog_entry.rs`
+- `src/app/commands/copy/mod.rs`
+- `src/app/commands/list/mod.rs`
+- `src/app/commands/checkout/mod.rs`
+- `src/adapters/snippet_catalog/filesystem_catalog.rs`

--- a/.jules/exchange/events/redundant_frontmatter_parsing_data_arch.md
+++ b/.jules/exchange/events/redundant_frontmatter_parsing_data_arch.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-03-30"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Duplicate code exists for parsing frontmatter. The `strip_frontmatter` and `parse_frontmatter` functions in `src/domain/snippet/frontmatter.rs` duplicate logic for finding frontmatter fences.
+
+## Goal
+
+Consolidate the frontmatter logic so the file content isn't parsed multiple times with duplicate logic, creating a unified parsed state.
+
+## Context
+
+Having duplicate implementations for finding frontmatter logic is error-prone, violates the DRY principle, and creates unnecessary coupling when changing the format. A single parsed state should be derived and passed along instead.
+
+## Evidence
+
+- path: "src/domain/snippet/frontmatter.rs"
+  loc: "line 8 and 32"
+  note: "`strip_frontmatter` and `parse_frontmatter` both independently implement fence logic, instead of parsing once and representing as a single entity (facts + derivations)."
+
+## Change Scope
+
+- `src/domain/snippet/frontmatter.rs`

--- a/.jules/exchange/events/redundant_path_validation_data_arch.md
+++ b/.jules/exchange/events/redundant_path_validation_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-30"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Duplicate code exists for path traversal and absolute path validation. `validate_relative_components` in `src/domain/context_file/path_policy.rs`, `ensure_safe_segments` in `src/domain/snippet/query.rs`, and `extract_relative_path` in `src/app/commands/add/mod.rs` implement nearly identical path component validation logic.
+
+## Goal
+
+Consolidate path validation logic into a single shared utility or enforce it within a common path type to ensure consistent security policy and reduce duplication.
+
+## Context
+
+Security constraints like preventing path traversals should be implemented uniformly to avoid gaps or discrepancies. Implementing it in three different locations creates a risk of diverging logic. A single shared policy or boundary validation is essential for Single Source of Truth for this validation.
+
+## Evidence
+
+- path: "src/domain/context_file/path_policy.rs"
+  loc: "line 6"
+  note: "`validate_relative_components` enforces `Component::Normal` or `Component::CurDir`."
+- path: "src/domain/snippet/query.rs"
+  loc: "line 22"
+  note: "`ensure_safe_segments` enforces `Component::Normal` or `Component::CurDir`."
+- path: "src/app/commands/add/mod.rs"
+  loc: "line 22"
+  note: "`extract_relative_path` enforces `Component::Normal` or `Component::CurDir` inside the loop."
+
+## Change Scope
+
+- `src/domain/context_file/path_policy.rs`
+- `src/domain/snippet/query.rs`
+- `src/app/commands/add/mod.rs`


### PR DESCRIPTION
Added three `data_arch` observer event files analyzing data models and data flow efficiency in the codebase. Findings point out domain boundary leaks (filesystem coupling) and duplicated code logic across the repository (frontmatter parsing and path validation).

---
*PR created automatically by Jules for task [6884043102623742239](https://jules.google.com/task/6884043102623742239) started by @akitorahayashi*