### PR TITLE
Emit observer events for Rust improvements

### DIFF
--- a/.jules/exchange/events/silent_frontmatter_failures_rustacean.md
+++ b/.jules/exchange/events/silent_frontmatter_failures_rustacean.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2024-05-18"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+In the `list` command (`execute`), retrieving snippet metadata uses `.ok()` chained after `fs::read_to_string` and later uses `.unwrap_or((None, None))`. This silently catches and drops all IO errors and potential parse failures, treating broken or inaccessible snippet files identically to those without frontmatter.
+
+## Goal
+
+Eliminate the silent fallback by explicitly handling I/O and parsing errors. Distinguish between a missing frontmatter (valid state) and an unreadable file or unparseable metadata block (invalid/error state), logging or propagating the error appropriately.
+
+## Context
+
+Silent fallback mechanisms that collapse operational failures (IO errors, permission denied) with expected defaults ("no data present") mask underlying bugs, corrupt configurations, or permission faults. Such operations should fail predictably and loudly.
+
+## Evidence
+
+- path: "src/app/commands/list/mod.rs"
+  loc: "18-24"
+  note: "`fs::read_to_string(...).ok()` discards underlying I/O error and `unwrap_or` defaults to `(None, None)` for all failures."
+
+## Change Scope
+
+- `src/app/commands/list/mod.rs`

--- a/.jules/exchange/events/stringly_typed_errors_rustacean.md
+++ b/.jules/exchange/events/stringly_typed_errors_rustacean.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+`AppError` heavily relies on `String` variants (e.g., `ConfigError(String)`, `NotFound(String)`, `ClipboardError(String)`, `InvalidKey(String)`, `PathTraversal(String)`). This collapses underlying typed errors (like parsing, IO, configuration issues) into untyped strings, losing context and semantic classification across boundaries.
+
+## Goal
+
+Redesign the error contract to use typed variants that preserve domain meaning, semantic classification, and structured context (e.g., the specific operation, ID, or input that failed). Replace generic strings with precise types or dynamic context attachment.
+
+## Context
+
+Using string-based errors (often referred to as "stringly-typed" errors) is an anti-pattern in Rust. It forces consumers of the API (even internal ones) to rely on string matching if they need to differentiate failures, making the error contract fragile and difficult to diagnose programmatically.
+
+## Evidence
+
+- path: "src/domain/error.rs"
+  loc: "4-20"
+  note: "Definition of AppError shows heavy reliance on String variants instead of strongly typed context."
+
+## Change Scope
+
+- `src/domain/error.rs`
+- `src/domain/snippet/query.rs`
+- `src/adapters/snippet_catalog/filesystem_catalog.rs`
+- `src/app/commands/add/mod.rs`
+- `src/adapters/clipboard/system_clipboard.rs`

--- a/.jules/exchange/events/untyped_path_invariants_rustacean.md
+++ b/.jules/exchange/events/untyped_path_invariants_rustacean.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Functions that perform domain invariant checks (like `validate_path` or `normalize_query`) perform verification but return standard `PathBuf` or `String`. The type system does not statically guarantee that a path has been validated, leading to repeated checks or implicit trust across module boundaries.
+
+## Goal
+
+Create strong domain types (e.g., `ValidatedContextPath` or `SafeSnippetPath`) that encapsulate the validity invariant. Operations requiring a safe path should demand this type at their API boundary, making invalid state unrepresentable.
+
+## Context
+
+Relying on out-of-band functions like `validate_path` before passing raw `String` or `PathBuf` variables spreads validation logic and requires developers to remember to call it. Encapsulating validated data in a custom type moves the check to the type boundary.
+
+## Evidence
+
+- path: "src/domain/context_file/path_policy.rs"
+  loc: "14-20"
+  note: "`validate_path` performs the invariant check but returns `Result<(), AppError>`, leaving the underlying path type uncertified."
+- path: "src/domain/snippet/query.rs"
+  loc: "4-18"
+  note: "`normalize_query` enforces paths are clean but returns an untyped `String`."
+
+## Change Scope
+
+- `src/domain/context_file/path_policy.rs`
+- `src/domain/context_file/key.rs`
+- `src/domain/snippet/query.rs`
+- `src/app/commands/touch/mod.rs`


### PR DESCRIPTION
Emit observer events for Rust improvements

Created three event files documenting high-signal findings related to stringly-typed errors, untyped path invariants, and silent failures in frontmatter parsing, in accordance with the rustacean role.

---
*PR created automatically by Jules for task [12665840343325290389](https://jules.google.com/task/12665840343325290389) started by @akitorahayashi*