### PR TITLE
docs(consistency): Document `mx command` vs `mx copy` mismatch

### DIFF
--- a/.jules/exchange/events/cli_copy_command_mismatch_consistency.md
+++ b/.jules/exchange/events/cli_copy_command_mismatch_consistency.md
@@ -1,0 +1,42 @@
+---
+label: "docs"
+created_at: "2024-05-30"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation in `README.md` and `docs/cli-usage.md` claims that the CLI supports a `mx command <snippet>` command to copy snippets to the clipboard. However, the implemented command is actually `mx copy <snippet>`. The CLI does not recognize the `command` subcommand.
+
+## Goal
+
+Update the documentation to correctly reflect the implemented command (`mx copy`), ensuring that users following the documentation verbatim will succeed.
+
+## Context
+
+The CLI provides a command to copy snippets to the clipboard. The code implements this as the `copy` command (`mx copy`), with an alias of `c`. However, `README.md` and `docs/cli-usage.md` erroneously refer to this command as `mx command`, leading to a "unrecognized subcommand" error when users try to execute the documented command.
+
+## Evidence
+
+- path: "README.md"
+  loc: "line 5"
+  note: "Documents `mx command <snippet>` instead of `mx copy <snippet>`"
+
+- path: "docs/cli-usage.md"
+  loc: "line 11"
+  note: "Documents `mx command wc` instead of `mx copy wc`"
+
+- path: "src/app/cli/mod.rs"
+  loc: "line 29"
+  note: "Implementation defines the command as `Copy`, accessible via `copy` or `c`."
+
+- path: "src/app/cli/mod.rs"
+  loc: "lines 22-54"
+  note: "No `Command` variant exists in the `Commands` enum; `mx command` is not implemented."
+
+## Change Scope
+
+- `README.md`
+- `docs/cli-usage.md`
+- `AGENTS.md`


### PR DESCRIPTION
This pull request addresses a documentation inconsistency found in the CLI. The documentation in `README.md` and `docs/cli-usage.md` erroneously claims that the CLI uses `mx command <snippet>` to copy snippets, whereas the actual command is `mx copy <snippet>`. 

An event file (`.jules/exchange/events/cli_copy_command_mismatch_consistency.md`) has been created to document this drift between the implemented behavior and its documented representation.

---
*PR created automatically by Jules for task [16784947535112850082](https://jules.google.com/task/16784947535112850082) started by @akitorahayashi*