### PR TITLE
chore(qa): emit test quality events

### DIFF
--- a/.jules/exchange/events/flake_risk_io_qa.md
+++ b/.jules/exchange/events/flake_risk_io_qa.md
@@ -1,0 +1,45 @@
+---
+label: "refacts"
+created_at: "2024-03-30"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Application commands `copy` and `list` unnecessarily perform direct filesystem reads from `std::fs` after resolving entities via the `SnippetCatalog` abstraction port, which couples core logic to side effects and degrades test isolation.
+
+## Goal
+
+Decouple the `copy` and `list` commands from direct file I/O by having the `SnippetCatalog` (or `SnippetStore`) provide snippet contents.
+
+## Context
+
+The `copy` and `list` commands isolate snippet lookup with `SnippetCatalog`, but then immediately fall back to `fs::read_to_string(&snippet_entry.absolute_path)` for the content. This forces pure logic testing to use `tempfile` and `fs::write` just to mock the contents. A better seam would abstract reading the contents, allowing tests to run entirely in memory.
+
+## Evidence
+
+- path: "src/app/commands/copy/mod.rs"
+  loc: "23"
+  note: "Direct `fs::read_to_string` couples `copy` command to the filesystem."
+
+- path: "src/app/commands/copy/mod.rs"
+  loc: "94-100"
+  note: "Forces `tempfile` and `fs::write` into pure unit tests to satisfy the hardcoded `fs` read."
+
+- path: "src/app/commands/list/mod.rs"
+  loc: "21"
+  note: "Direct `fs::read_to_string` couples `list` command to the filesystem to read frontmatter."
+
+- path: "src/app/commands/list/mod.rs"
+  loc: "48-60"
+  note: "Forces `tempfile` and `fs::write` into pure unit tests to satisfy the hardcoded `fs` read."
+
+## Change Scope
+
+- `src/app/commands/copy/mod.rs`
+- `src/app/commands/list/mod.rs`
+- `src/domain/ports/snippet_store.rs`
+- `src/domain/ports/snippet_catalog.rs`
+- `src/testing/ports/in_memory_catalog.rs`
+- `src/adapters/snippet_catalog/filesystem_catalog.rs`

--- a/.jules/exchange/events/redundant_tests_qa.md
+++ b/.jules/exchange/events/redundant_tests_qa.md
@@ -1,0 +1,34 @@
+---
+label: "tests"
+created_at: "2024-03-30"
+author_role: "qa"
+confidence: "medium"
+---
+
+## Problem
+
+Duplicate test configurations exist within `src/app/commands` app tests and `tests/cli` CLI integration tests.
+
+## Goal
+
+Ensure `tests/cli` only exercises the CLI boundaries (args parsing, process return codes, and system boundaries) while the exhaustive business logic paths are tested in the lightweight in-memory `src/app/commands/*/mod.rs` tests.
+
+## Context
+
+For commands like `add`, `touch`, `copy` and `list`, the application tests cover detailed validation paths and side effects, but the integration tests (`tests/cli/add.rs`, etc.) often replicate similar checks (e.g. `add_fails_on_duplicate_without_force`, `add_rejects_path_outside_mx_commands` in `tests/cli/add.rs` replicate checks that should exist solely at the unit level).
+
+## Evidence
+
+- path: "tests/cli/add.rs"
+  loc: "55-63"
+  note: "Tests duplicate failure condition (`add_fails_on_duplicate_without_force`) that is purely domain logic and best verified in `src/app/commands/add/mod.rs`."
+
+- path: "tests/cli/add.rs"
+  loc: "80-88"
+  note: "Tests reject condition (`add_rejects_path_outside_mx_commands`) duplicated between integration and unit testing."
+
+## Change Scope
+
+- `tests/cli/add.rs`
+- `tests/cli/touch.rs`
+- `tests/cli/copy.rs`

--- a/.jules/exchange/events/unverified_flake_retries_qa.md
+++ b/.jules/exchange/events/unverified_flake_retries_qa.md
@@ -1,0 +1,35 @@
+---
+label: "tests"
+created_at: "2024-03-30"
+author_role: "qa"
+confidence: "medium"
+---
+
+## Problem
+
+Integration tests rely on hardcoded paths inside temporary directories via `tempfile::tempdir().unwrap()` combined with hardcoded strings rather than robust assertions of output structure, potentially leading to flaky assertions if the environment changes. Test files use `fs::read_to_string` to assert on test success.
+
+## Goal
+
+Ensure integration tests assert on externally observable behavior (stdout/stderr or correctly abstracted context reads) rather than deeply coupling to implementation details (like exact filesystem states using real I/O).
+
+## Context
+
+Many test files (e.g., `tests/cli/cat.rs`, `tests/cli/touch.rs`, `tests/cli/clean.rs`, `tests/context/lifecycle.rs`) create temporary directories and hardcode assertions that files exist in a specific structure, relying heavily on `.unwrap()`. This couples the tests tightly to the file system instead of relying on the abstractions created.
+
+## Evidence
+
+- path: "tests/cli/cat.rs"
+  loc: "8-16"
+  note: "Uses `tempfile::tempdir().unwrap()` and hardcoded strings for paths and file contents to setup test scenarios instead of relying on harness abstractions."
+
+- path: "tests/context/lifecycle.rs"
+  loc: "8-29"
+  note: "Ties test success to arbitrary filesystem structure checks like `dir.path().join(\"clipboard.txt\")`."
+
+## Change Scope
+
+- `tests/cli/cat.rs`
+- `tests/cli/touch.rs`
+- `tests/cli/clean.rs`
+- `tests/context/lifecycle.rs`


### PR DESCRIPTION
This PR introduces 3 quality assurance observer events evaluating test structure across the repository:
- `flake_risk_io_qa.md`: Flags direct `std::fs` usage inside application command tests (`copy`, `list`) which defeats the purpose of the `InMemoryCatalog` abstraction and introduces flake risk through hardcoded file creation in tests.
- `redundant_tests_qa.md`: Identifies duplicated business logic checks (like "fails on duplicate without force") being tested both at the integration boundary (`tests/cli/add.rs`) and unit boundary (`src/app/commands/add/mod.rs`), slowing down test execution unnecessarily.
- `unverified_flake_retries_qa.md`: Details brittle setups in integration tests like `tests/cli/cat.rs` which couple to deeply nested paths using `.unwrap()` and `tempfile`, instead of robust stdout assertions.

All modifications are confined strictly to `.jules/exchange/events/`.

---
*PR created automatically by Jules for task [15427111652129895086](https://jules.google.com/task/15427111652129895086) started by @akitorahayashi*