### PR TITLE
Emit test coverage events for core adapters

### DIFF
--- a/.jules/exchange/events/file_clipboard_coverage_cov.md
+++ b/.jules/exchange/events/file_clipboard_coverage_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Coverage is lacking in error paths for `FileClipboard` (`src/adapters/clipboard/file_clipboard.rs`), specifically the `AppError::clipboard_error` mapping on failed IO operations.
+
+## Goal
+
+Add explicit tests for `FileClipboard` read/write failure conditions (e.g., unwritable or unreadable files) to ensure correct error types are propagated.
+
+## Context
+
+The `FileClipboard` adapter implements the `Clipboard` port using a file on disk. While the happy path is covered by `file_clipboard_roundtrip`, the error handling when reading from or writing to the file fails is untested. Ensuring these errors are correctly translated to `AppError::clipboard_error` is necessary for consistent API behavior.
+
+## Evidence
+
+- path: "src/adapters/clipboard/file_clipboard.rs"
+  loc: "lines 27-28"
+  note: "Reading `src/adapters/clipboard/file_clipboard.rs` shows an untested error handler when mapping `fs::read_to_string` result and unhandled failure modes."
+
+## Change Scope
+
+- `src/adapters/clipboard/file_clipboard.rs`

--- a/.jules/exchange/events/filesystem_store_env_coverage_cov.md
+++ b/.jules/exchange/events/filesystem_store_env_coverage_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+`FilesystemSnippetStore::from_env` logic in `src/adapters/snippet_store/filesystem_store.rs` lacks coverage for fallback resolution and error handling when detecting the command root path from the environment.
+
+## Goal
+
+Add targeted tests for `FilesystemSnippetStore::from_env` to verify correct `MX_COMMANDS_ROOT` resolution, backward compatibility checks (`commands` subdirectory presence), and the default `.config/mx/commands` fallback behavior.
+
+## Context
+
+The system discovers snippets starting from an environment-specified or user-local root directory. This logic contains conditionals for legacy setups (where an extra `commands` subfolder was implicitly required). If the resolution fails or produces incorrect paths, file reads/writes fail systemically. Adding coverage for this logic secures the filesystem resolution.
+
+## Evidence
+
+- path: "src/adapters/snippet_store/filesystem_store.rs"
+  loc: "FilesystemSnippetStore::from_env logic"
+  note: "Reading `src/adapters/snippet_store/filesystem_store.rs` reveals fallback and environment variable processing paths that require integration testing to prevent configuration breakage."
+
+## Change Scope
+
+- `src/adapters/snippet_store/filesystem_store.rs`

--- a/.jules/exchange/events/system_clipboard_coverage_cov.md
+++ b/.jules/exchange/events/system_clipboard_coverage_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The `SystemClipboard` adapter (`src/adapters/clipboard/system_clipboard.rs`) lacks test coverage for its behavior on different OS configurations, meaning the logic is untested. This represents a critical gap in functionality validation for an external system integration boundary.
+
+## Goal
+
+Add tests for the `SystemClipboard` implementation to verify the behavior of the clipboard commands on different OS configurations, handle missing dependencies properly, and ensure robust error states, eliminating this coverage blackhole.
+
+## Context
+
+The `SystemClipboard` component detects and shells out to OS-specific tools (pbcopy, xclip, wl-copy, etc.) for reading and writing clipboard contents. This is a crucial function for users adding snippets to/from the clipboard. Currently, coverage is absent, and changes to the OS detection logic or process-spawning logic run a high risk of undetected regression.
+
+## Evidence
+
+- path: "src/adapters/clipboard/system_clipboard.rs"
+  loc: "SystemClipboard implementation block"
+  note: "Reading `src/adapters/clipboard/system_clipboard.rs` shows complex conditional compilation and shell executions that should have corresponding tests."
+
+## Change Scope
+
+- `src/adapters/clipboard/system_clipboard.rs`


### PR DESCRIPTION
Added `.jules/exchange/events/system_clipboard_coverage_cov.md`, `.jules/exchange/events/filesystem_store_env_coverage_cov.md`, and `.jules/exchange/events/file_clipboard_coverage_cov.md` documenting missing test coverage for OS command execution, filesystem logic fallback, and clipboard error propagation mapping respectively.

---
*PR created automatically by Jules for task [8244201151336214866](https://jules.google.com/task/8244201151336214866) started by @akitorahayashi*