### PR TITLE
docs: Update documentation for `mx copy` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `mx` is a Rust CLI that unifies two daily workflows:
 
-1. **Snippet command** – type `mx command <snippet>` (alias `mx c`) to stream any markdown snippet under
+1. **Snippet command** – type `mx copy <snippet>` (alias `mx c`) to stream any markdown snippet under
    `~/.config/mx/commands/` into your clipboard.
 2. **Context Orchestration** – type `mx touch <key>` (alias `mx t`) to create context files in your project with clipboard content, and `mx cat <key>` (alias `mx ct`) to view their contents.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `mx` is a Rust CLI that unifies two daily workflows:
 
-1. **Snippet command** – type `mx copy <snippet>` (alias `mx c`) to stream any markdown snippet under
+1. **Snippet copy** – type `mx copy <snippet>` (alias `mx c`) to stream any markdown snippet under
    `~/.config/mx/commands/` into your clipboard.
 2. **Context Orchestration** – type `mx touch <key>` (alias `mx t`) to create context files in your project with clipboard content, and `mx cat <key>` (alias `mx ct`) to view their contents.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -8,7 +8,7 @@ mx list (alias: ls)
 mx --version
 
 # Copy a snippet into the clipboard (uses pbcopy/wl-copy/xclip/clip automatically)
-mx command wc (alias: mx c wc)
+mx copy wc (alias: mx c wc)
 
 # Create context files with clipboard content (alias: mx t)
 mx touch tk   # Creates .mx/tasks.md with clipboard content


### PR DESCRIPTION
Update documentation in README.md and docs/cli-usage.md to correctly reflect that the CLI uses `mx copy <snippet>` instead of `mx command <snippet>`.

---
*PR created automatically by Jules for task [12088562944762639319](https://jules.google.com/task/12088562944762639319) started by @akitorahayashi*