### PR TITLE
Refactor stringly-typed errors to strongly-typed domain structures

### DIFF
--- a/src/adapters/clipboard/file_clipboard.rs
+++ b/src/adapters/clipboard/file_clipboard.rs
@@ -18,14 +18,18 @@ impl FileClipboard {
 
 impl Clipboard for FileClipboard {
     fn copy(&self, text: &str) -> Result<(), AppError> {
-        fs::write(&self.path, text).map_err(|err| AppError::ClipboardError(crate::domain::error::ClipboardError::Other(err.to_string())))
+        fs::write(&self.path, text).map_err(|err| {
+            AppError::ClipboardError(crate::domain::error::ClipboardError::Other(err.to_string()))
+        })
     }
 
     fn paste(&self) -> Result<String, AppError> {
         match fs::read_to_string(&self.path) {
             Ok(content) => Ok(content),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
-            Err(err) => Err(AppError::ClipboardError(crate::domain::error::ClipboardError::Other(err.to_string()))),
+            Err(err) => Err(AppError::ClipboardError(crate::domain::error::ClipboardError::Other(
+                err.to_string(),
+            ))),
         }
     }
 }

--- a/src/adapters/clipboard/file_clipboard.rs
+++ b/src/adapters/clipboard/file_clipboard.rs
@@ -18,14 +18,14 @@ impl FileClipboard {
 
 impl Clipboard for FileClipboard {
     fn copy(&self, text: &str) -> Result<(), AppError> {
-        fs::write(&self.path, text).map_err(|err| AppError::clipboard_error(err.to_string()))
+        fs::write(&self.path, text).map_err(|err| AppError::ClipboardError(crate::domain::error::ClipboardError::Other(err.to_string())))
     }
 
     fn paste(&self) -> Result<String, AppError> {
         match fs::read_to_string(&self.path) {
             Ok(content) => Ok(content),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
-            Err(err) => Err(AppError::clipboard_error(err.to_string())),
+            Err(err) => Err(AppError::ClipboardError(crate::domain::error::ClipboardError::Other(err.to_string()))),
         }
     }
 }

--- a/src/adapters/clipboard/system_clipboard.rs
+++ b/src/adapters/clipboard/system_clipboard.rs
@@ -179,7 +179,6 @@ impl Clipboard for SystemClipboard {
                 AppError::ClipboardError(ClipboardError::InvalidUtf8(err.to_string()))
             })
         } else {
-            let _stderr = String::from_utf8_lossy(&output.stderr);
             Err(AppError::ClipboardError(ClipboardError::NonZeroExit(
                 output.status.code().unwrap_or(-1),
             )))

--- a/src/adapters/clipboard/system_clipboard.rs
+++ b/src/adapters/clipboard/system_clipboard.rs
@@ -43,10 +43,12 @@ impl SystemClipboard {
         let paste_var = env::var("MX_PASTE_CMD");
 
         if let (Ok(copy_str), Ok(paste_str)) = (copy_var.as_ref(), paste_var.as_ref()) {
-            let copy_command = ClipboardCommand::from_string(copy_str)
-                .ok_or_else(|| AppError::ClipboardError(ClipboardError::CommandMissing("MX_COPY_CMD".to_string())))?;
-            let paste_command = ClipboardCommand::from_string(paste_str)
-                .ok_or_else(|| AppError::ClipboardError(ClipboardError::CommandMissing("MX_PASTE_CMD".to_string())))?;
+            let copy_command = ClipboardCommand::from_string(copy_str).ok_or_else(|| {
+                AppError::ClipboardError(ClipboardError::CommandMissing("MX_COPY_CMD".to_string()))
+            })?;
+            let paste_command = ClipboardCommand::from_string(paste_str).ok_or_else(|| {
+                AppError::ClipboardError(ClipboardError::CommandMissing("MX_PASTE_CMD".to_string()))
+            })?;
             return Ok(Self { copy_command, paste_command });
         }
 
@@ -57,8 +59,11 @@ impl SystemClipboard {
         }
 
         if let Ok(custom) = env::var("MX_CLIPBOARD_CMD") {
-            let command = ClipboardCommand::from_string(&custom)
-                .ok_or_else(|| AppError::ClipboardError(ClipboardError::CommandMissing("MX_CLIPBOARD_CMD".to_string())))?;
+            let command = ClipboardCommand::from_string(&custom).ok_or_else(|| {
+                AppError::ClipboardError(ClipboardError::CommandMissing(
+                    "MX_CLIPBOARD_CMD".to_string(),
+                ))
+            })?;
             return Ok(Self { copy_command: command.clone(), paste_command: command });
         }
 
@@ -76,7 +81,9 @@ impl SystemClipboard {
                     "Get-Clipboard",
                 ]),
             }),
-            other => Err(AppError::ClipboardError(ClipboardError::UnsupportedPlatform(other.to_string()))),
+            other => Err(AppError::ClipboardError(ClipboardError::UnsupportedPlatform(
+                other.to_string(),
+            ))),
         }
     }
 
@@ -141,9 +148,11 @@ impl Clipboard for SystemClipboard {
             })?;
         }
 
-        let status = child
-            .wait()
-            .map_err(|err| AppError::ClipboardError(ClipboardError::ExecutionFailed(format!("Clipboard command failed: {err}"))))?;
+        let status = child.wait().map_err(|err| {
+            AppError::ClipboardError(ClipboardError::ExecutionFailed(format!(
+                "Clipboard command failed: {err}"
+            )))
+        })?;
 
         if status.success() {
             Ok(())
@@ -171,7 +180,9 @@ impl Clipboard for SystemClipboard {
             })
         } else {
             let _stderr = String::from_utf8_lossy(&output.stderr);
-            Err(AppError::ClipboardError(ClipboardError::NonZeroExit(output.status.code().unwrap_or(-1))))
+            Err(AppError::ClipboardError(ClipboardError::NonZeroExit(
+                output.status.code().unwrap_or(-1),
+            )))
         }
     }
 }

--- a/src/adapters/clipboard/system_clipboard.rs
+++ b/src/adapters/clipboard/system_clipboard.rs
@@ -1,4 +1,4 @@
-use crate::domain::error::AppError;
+use crate::domain::error::{AppError, ClipboardError, ConfigError};
 use crate::domain::ports::Clipboard;
 use std::env;
 use std::io::Write;
@@ -44,21 +44,21 @@ impl SystemClipboard {
 
         if let (Ok(copy_str), Ok(paste_str)) = (copy_var.as_ref(), paste_var.as_ref()) {
             let copy_command = ClipboardCommand::from_string(copy_str)
-                .ok_or_else(|| AppError::clipboard_error("MX_COPY_CMD is empty"))?;
+                .ok_or_else(|| AppError::ClipboardError(ClipboardError::CommandMissing("MX_COPY_CMD".to_string())))?;
             let paste_command = ClipboardCommand::from_string(paste_str)
-                .ok_or_else(|| AppError::clipboard_error("MX_PASTE_CMD is empty"))?;
+                .ok_or_else(|| AppError::ClipboardError(ClipboardError::CommandMissing("MX_PASTE_CMD".to_string())))?;
             return Ok(Self { copy_command, paste_command });
         }
 
         if copy_var.is_ok() || paste_var.is_ok() {
-            return Err(AppError::clipboard_error(
-                "Both MX_COPY_CMD and MX_PASTE_CMD must be set if either is provided",
-            ));
+            return Err(AppError::ConfigError(ConfigError::Other(
+                "Both MX_COPY_CMD and MX_PASTE_CMD must be set if either is provided".to_string(),
+            )));
         }
 
         if let Ok(custom) = env::var("MX_CLIPBOARD_CMD") {
             let command = ClipboardCommand::from_string(&custom)
-                .ok_or_else(|| AppError::clipboard_error("MX_CLIPBOARD_CMD is empty"))?;
+                .ok_or_else(|| AppError::ClipboardError(ClipboardError::CommandMissing("MX_CLIPBOARD_CMD".to_string())))?;
             return Ok(Self { copy_command: command.clone(), paste_command: command });
         }
 
@@ -76,9 +76,7 @@ impl SystemClipboard {
                     "Get-Clipboard",
                 ]),
             }),
-            other => Err(AppError::clipboard_error(format!(
-                "Unsupported platform '{other}' for clipboard operations"
-            ))),
+            other => Err(AppError::ClipboardError(ClipboardError::UnsupportedPlatform(other.to_string()))),
         }
     }
 
@@ -101,9 +99,9 @@ impl SystemClipboard {
             });
         }
 
-        Err(AppError::clipboard_error(
-            "No supported clipboard command found. Install wl-copy or xclip, or set MX_CLIPBOARD_FILE.",
-        ))
+        Err(AppError::ClipboardError(ClipboardError::UnsupportedPlatform(
+            "No supported clipboard command found. Install wl-copy or xclip, or set MX_CLIPBOARD_FILE.".to_string()
+        )))
     }
 
     fn command_available<'a, I>(program: &str, args: I) -> bool
@@ -129,28 +127,28 @@ impl Clipboard for SystemClipboard {
             .stderr(Stdio::null());
 
         let mut child = command.spawn().map_err(|err| {
-            AppError::clipboard_error(format!(
+            AppError::ClipboardError(ClipboardError::ExecutionFailed(format!(
                 "Failed to run clipboard command '{}': {err}",
                 self.copy_command.program
-            ))
+            )))
         })?;
 
         if let Some(mut stdin) = child.stdin.take() {
             stdin.write_all(text.as_bytes()).map_err(|err| {
-                AppError::clipboard_error(format!(
+                AppError::ClipboardError(ClipboardError::Other(format!(
                     "Failed to send data to clipboard command: {err}"
-                ))
+                )))
             })?;
         }
 
         let status = child
             .wait()
-            .map_err(|err| AppError::clipboard_error(format!("Clipboard command failed: {err}")))?;
+            .map_err(|err| AppError::ClipboardError(ClipboardError::ExecutionFailed(format!("Clipboard command failed: {err}"))))?;
 
         if status.success() {
             Ok(())
         } else {
-            Err(AppError::clipboard_error(format!("Clipboard command exited with status {status}")))
+            Err(AppError::ClipboardError(ClipboardError::NonZeroExit(status.code().unwrap_or(-1))))
         }
     }
 
@@ -161,23 +159,19 @@ impl Clipboard for SystemClipboard {
             .stderr(Stdio::piped())
             .output()
             .map_err(|err| {
-                AppError::clipboard_error(format!(
+                AppError::ClipboardError(ClipboardError::ExecutionFailed(format!(
                     "Failed to run paste command '{}': {err}",
                     self.paste_command.program
-                ))
+                )))
             })?;
 
         if output.status.success() {
             String::from_utf8(output.stdout).map_err(|err| {
-                AppError::clipboard_error(format!("Clipboard content is not valid UTF-8: {err}"))
+                AppError::ClipboardError(ClipboardError::InvalidUtf8(err.to_string()))
             })
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(AppError::clipboard_error(format!(
-                "Paste command exited with status {}. Stderr: {}",
-                output.status,
-                stderr.trim()
-            )))
+            let _stderr = String::from_utf8_lossy(&output.stderr);
+            Err(AppError::ClipboardError(ClipboardError::NonZeroExit(output.status.code().unwrap_or(-1))))
         }
     }
 }

--- a/src/adapters/context_file_store/local_context_store.rs
+++ b/src/adapters/context_file_store/local_context_store.rs
@@ -1,5 +1,5 @@
 use crate::domain::context_file::path_policy::validate_relative_components;
-use crate::domain::error::AppError;
+use crate::domain::error::{AppError, NotFoundError, PathTraversalError};
 use crate::domain::ports::{ContextFileStore, ContextWriteStatus};
 use std::ffi::OsStr;
 use std::fs;
@@ -66,9 +66,9 @@ impl ContextFileStore for LocalContextFileStore {
 
     fn write_context_contents(&self, absolute_path: &Path, contents: &str) -> Result<(), AppError> {
         if !absolute_path.starts_with(self.mx_dir()) {
-            return Err(AppError::path_traversal(
-                "Invalid path. Cannot create files outside of .mx directory.",
-            ));
+            return Err(AppError::PathTraversal(PathTraversalError::Detected(
+                "Invalid path. Cannot create files outside of .mx directory.".to_string(),
+            )));
         }
         fs::write(absolute_path, contents)?;
         Ok(())
@@ -80,16 +80,16 @@ impl ContextFileStore for LocalContextFileStore {
 
         if !full_path.is_file() {
             if full_path.exists() {
-                return Err(AppError::not_found(format!(
+                return Err(AppError::NotFound(NotFoundError::ContextFile(format!(
                     "⚠️ Path is not a file: {}",
                     relative_path.display()
-                )));
+                ))));
             }
 
-            return Err(AppError::not_found(format!(
+            return Err(AppError::NotFound(NotFoundError::ContextFile(format!(
                 "⚠️ Context file not found: {}",
                 relative_path.display()
-            )));
+            ))));
         }
 
         fs::read_to_string(&full_path).map_err(|err| {
@@ -146,7 +146,7 @@ impl ContextFileStore for LocalContextFileStore {
             return Ok(target_path);
         }
 
-        Err(AppError::not_found(format!("File not found: {}", target_path.display())))
+        Err(AppError::NotFound(crate::domain::error::NotFoundError::File(format!("File not found: {}", target_path.display()))))
     }
 
     fn read_workspace_file(&self, relative_path: &Path) -> Result<String, std::io::Error> {
@@ -182,7 +182,7 @@ mod tests {
         let store = LocalContextFileStore::new(workspace.path().to_path_buf());
 
         let result = store.prepare_context_file(Path::new("../escape.md"), false);
-        assert!(matches!(result, Err(AppError::PathTraversal(_))));
+        assert!(matches!(result, Err(AppError::PathTraversal(PathTraversalError::Detected(_)))));
     }
 
     #[test]
@@ -192,7 +192,7 @@ mod tests {
         let outside = workspace.path().join("outside.md");
 
         let result = store.write_context_contents(&outside, "content");
-        assert!(matches!(result, Err(AppError::PathTraversal(_))));
+        assert!(matches!(result, Err(AppError::PathTraversal(PathTraversalError::Detected(_)))));
     }
 
     #[test]

--- a/src/adapters/context_file_store/local_context_store.rs
+++ b/src/adapters/context_file_store/local_context_store.rs
@@ -146,7 +146,10 @@ impl ContextFileStore for LocalContextFileStore {
             return Ok(target_path);
         }
 
-        Err(AppError::NotFound(crate::domain::error::NotFoundError::File(format!("File not found: {}", target_path.display()))))
+        Err(AppError::NotFound(crate::domain::error::NotFoundError::File(format!(
+            "File not found: {}",
+            target_path.display()
+        ))))
     }
 
     fn read_workspace_file(&self, relative_path: &Path) -> Result<String, std::io::Error> {

--- a/src/adapters/snippet_catalog/filesystem_catalog.rs
+++ b/src/adapters/snippet_catalog/filesystem_catalog.rs
@@ -44,7 +44,8 @@ impl SnippetCatalog for FilesystemSnippetCatalog {
 
         let mut files = Vec::new();
         for entry in WalkDir::new(&self.commands_root) {
-            let entry = entry.map_err(|err| AppError::ConfigError(ConfigError::Io(err.to_string())))?;
+            let entry =
+                entry.map_err(|err| AppError::ConfigError(ConfigError::Io(err.to_string())))?;
             if !entry.file_type().is_file() {
                 continue;
             }
@@ -53,9 +54,11 @@ impl SnippetCatalog for FilesystemSnippetCatalog {
             }
 
             let path = entry.path();
-            let relative = path
-                .strip_prefix(&self.commands_root)
-                .map_err(|_| AppError::ConfigError(ConfigError::RelativePathDerivation(path.display().to_string())))?;
+            let relative = path.strip_prefix(&self.commands_root).map_err(|_| {
+                AppError::ConfigError(ConfigError::RelativePathDerivation(
+                    path.display().to_string(),
+                ))
+            })?;
             let relative_without_ext = relative.with_extension("");
             let relative_path = path_to_string(&relative_without_ext)?;
             let key = path

--- a/src/adapters/snippet_catalog/filesystem_catalog.rs
+++ b/src/adapters/snippet_catalog/filesystem_catalog.rs
@@ -64,7 +64,7 @@ impl SnippetCatalog for FilesystemSnippetCatalog {
             let key = path
                 .file_stem()
                 .and_then(|stem| stem.to_str())
-                .ok_or_else(|| AppError::ConfigError(ConfigError::InvalidUtf8))?
+                .ok_or(AppError::ConfigError(ConfigError::InvalidUtf8))?
                 .to_string();
 
             files.push(SnippetEntry { key, relative_path, absolute_path: entry.into_path() });

--- a/src/adapters/snippet_catalog/filesystem_catalog.rs
+++ b/src/adapters/snippet_catalog/filesystem_catalog.rs
@@ -1,4 +1,4 @@
-use crate::domain::error::AppError;
+use crate::domain::error::{AppError, ConfigError, NotFoundError};
 use crate::domain::ports::SnippetCatalog;
 use crate::domain::snippet::query::{candidate_key, normalize_query, path_to_string};
 use crate::domain::snippet::SnippetEntry;
@@ -22,7 +22,7 @@ impl FilesystemSnippetCatalog {
         }
 
         let home = env::var("HOME")
-            .map_err(|_| AppError::config_error("HOME environment variable not set"))?;
+            .map_err(|_| AppError::ConfigError(ConfigError::MissingEnvVar("HOME".to_string())))?;
         let root = PathBuf::from(home).join(".config").join("mx");
         Self::from_root(root)
     }
@@ -44,7 +44,7 @@ impl SnippetCatalog for FilesystemSnippetCatalog {
 
         let mut files = Vec::new();
         for entry in WalkDir::new(&self.commands_root) {
-            let entry = entry.map_err(|err| AppError::config_error(err.to_string()))?;
+            let entry = entry.map_err(|err| AppError::ConfigError(ConfigError::Io(err.to_string())))?;
             if !entry.file_type().is_file() {
                 continue;
             }
@@ -52,17 +52,16 @@ impl SnippetCatalog for FilesystemSnippetCatalog {
                 continue;
             }
 
-            let relative = entry
-                .path()
+            let path = entry.path();
+            let relative = path
                 .strip_prefix(&self.commands_root)
-                .map_err(|_| AppError::config_error("Unable to derive relative snippet path"))?;
+                .map_err(|_| AppError::ConfigError(ConfigError::RelativePathDerivation(path.display().to_string())))?;
             let relative_without_ext = relative.with_extension("");
             let relative_path = path_to_string(&relative_without_ext)?;
-            let key = entry
-                .path()
+            let key = path
                 .file_stem()
                 .and_then(|stem| stem.to_str())
-                .ok_or_else(|| AppError::config_error("Snippet names must be valid UTF-8"))?
+                .ok_or_else(|| AppError::ConfigError(ConfigError::InvalidUtf8))?
                 .to_string();
 
             files.push(SnippetEntry { key, relative_path, absolute_path: entry.into_path() });
@@ -92,24 +91,24 @@ impl SnippetCatalog for FilesystemSnippetCatalog {
         }
 
         if exact_matches.len() > 1 {
-            return Err(AppError::config_error(format!(
+            return Err(AppError::ConfigError(ConfigError::DuplicateSnippet(format!(
                 "Multiple snippets match '{raw_query}': {}",
                 Self::join_paths(&exact_matches)
-            )));
+            ))));
         }
 
         if key_matches.is_empty() {
-            return Err(AppError::not_found(format!(
+            return Err(AppError::NotFound(NotFoundError::Snippet(format!(
                 "No snippet named '{raw_query}' under {}",
                 self.commands_root.display()
-            )));
+            ))));
         }
 
         if key_matches.len() > 1 {
-            return Err(AppError::config_error(format!(
+            return Err(AppError::ConfigError(ConfigError::DuplicateSnippet(format!(
                 "Multiple snippets share the name '{raw_query}': {}",
                 Self::join_paths(&key_matches)
-            )));
+            ))));
         }
 
         Ok(key_matches.remove(0))

--- a/src/adapters/snippet_store/filesystem_store.rs
+++ b/src/adapters/snippet_store/filesystem_store.rs
@@ -1,4 +1,4 @@
-use crate::domain::error::{AppError, NotFoundError};
+use crate::domain::error::{AppError, ConfigError, NotFoundError};
 use crate::domain::ports::SnippetStore;
 use std::env;
 use std::fs;
@@ -17,11 +17,8 @@ impl FilesystemSnippetStore {
             return Ok(Self { commands_root });
         }
 
-        let home = env::var("HOME").map_err(|_| {
-            AppError::ConfigError(crate::domain::error::ConfigError::Other(
-                "HOME environment variable not set".to_string(),
-            ))
-        })?;
+        let home = env::var("HOME")
+            .map_err(|_| AppError::ConfigError(ConfigError::MissingEnvVar("HOME".to_string())))?;
         let root = PathBuf::from(home).join(".config").join("mx");
         Ok(Self { commands_root: root.join("commands") })
     }

--- a/src/adapters/snippet_store/filesystem_store.rs
+++ b/src/adapters/snippet_store/filesystem_store.rs
@@ -1,4 +1,4 @@
-use crate::domain::error::AppError;
+use crate::domain::error::{AppError, NotFoundError};
 use crate::domain::ports::SnippetStore;
 use std::env;
 use std::fs;
@@ -18,7 +18,7 @@ impl FilesystemSnippetStore {
         }
 
         let home = env::var("HOME")
-            .map_err(|_| AppError::config_error("HOME environment variable not set"))?;
+            .map_err(|_| AppError::ConfigError(crate::domain::error::ConfigError::Other("HOME environment variable not set".to_string())))?;
         let root = PathBuf::from(home).join(".config").join("mx");
         Ok(Self { commands_root: root.join("commands") })
     }
@@ -60,10 +60,10 @@ impl SnippetStore for FilesystemSnippetStore {
         };
 
         if !target.exists() {
-            return Err(AppError::not_found(format!(
+            return Err(AppError::NotFound(NotFoundError::Snippet(format!(
                 "Snippet file not found: {}",
                 target.display()
-            )));
+            ))));
         }
 
         fs::remove_file(&target)?;

--- a/src/adapters/snippet_store/filesystem_store.rs
+++ b/src/adapters/snippet_store/filesystem_store.rs
@@ -17,8 +17,11 @@ impl FilesystemSnippetStore {
             return Ok(Self { commands_root });
         }
 
-        let home = env::var("HOME")
-            .map_err(|_| AppError::ConfigError(crate::domain::error::ConfigError::Other("HOME environment variable not set".to_string())))?;
+        let home = env::var("HOME").map_err(|_| {
+            AppError::ConfigError(crate::domain::error::ConfigError::Other(
+                "HOME environment variable not set".to_string(),
+            ))
+        })?;
         let root = PathBuf::from(home).join(".config").join("mx");
         Ok(Self { commands_root: root.join("commands") })
     }

--- a/src/app/commands/add/mod.rs
+++ b/src/app/commands/add/mod.rs
@@ -1,4 +1,4 @@
-use crate::domain::error::AppError;
+use crate::domain::error::{AppError, InvalidKeyError, PathTraversalError, ConfigError};
 use crate::domain::ports::{Clipboard, SnippetStore};
 use crate::domain::snippet::SnippetFrontmatter;
 use std::path::{Path, PathBuf};
@@ -14,11 +14,14 @@ pub struct AddOutcome {
 fn extract_relative_path(raw_path: &str) -> Result<PathBuf, AppError> {
     let normalized = raw_path.trim_start_matches("./");
     let stripped = normalized.strip_prefix(".mx/commands/").ok_or_else(|| {
-        AppError::invalid_key(format!("Path must be under .mx/commands/ (got '{raw_path}')"))
+        AppError::InvalidKey(InvalidKeyError::NotInCommands {
+            expected: ".mx/commands/".to_string(),
+            actual: raw_path.to_string(),
+        })
     })?;
 
     if stripped.is_empty() {
-        return Err(AppError::invalid_key("Path cannot be empty after .mx/commands/"));
+        return Err(AppError::InvalidKey(InvalidKeyError::EmptyAfterPrefix(".mx/commands/".to_string())));
     }
 
     let rel = Path::new(stripped);
@@ -27,9 +30,9 @@ fn extract_relative_path(raw_path: &str) -> Result<PathBuf, AppError> {
         match component {
             Normal(_) | CurDir => {}
             _ => {
-                return Err(AppError::path_traversal(format!(
+                return Err(AppError::PathTraversal(PathTraversalError::Detected(format!(
                     "Path contains unsafe segments: '{raw_path}'"
-                )))
+                ))))
             }
         }
     }
@@ -48,10 +51,10 @@ pub fn execute(
     let relative = extract_relative_path(raw_path)?;
 
     if store.snippet_exists(&relative) && !force {
-        return Err(AppError::config_error(format!(
+        return Err(AppError::ConfigError(ConfigError::DuplicateSnippet(format!(
             "Snippet already exists: '{}'. Use --force to overwrite.",
             relative.display()
-        )));
+        ))));
     }
 
     let body = clipboard.paste()?;
@@ -126,7 +129,7 @@ mod tests {
         execute(".mx/commands/dup.md", None, None, false, &store, &clipboard).unwrap();
         let err = execute(".mx/commands/dup.md", None, None, false, &store, &clipboard)
             .expect_err("should fail on duplicate");
-        assert!(matches!(err, AppError::ConfigError(_)));
+        assert!(matches!(err, AppError::ConfigError(crate::domain::error::ConfigError::DuplicateSnippet(_))));
     }
 
     #[test]
@@ -147,6 +150,6 @@ mod tests {
 
         let err = execute("foo/bar.md", None, None, false, &store, &clipboard)
             .expect_err("should reject path outside .mx/commands/");
-        assert!(matches!(err, AppError::InvalidKey(_)));
+        assert!(matches!(err, AppError::InvalidKey(crate::domain::error::InvalidKeyError::NotInCommands { .. })));
     }
 }

--- a/src/app/commands/add/mod.rs
+++ b/src/app/commands/add/mod.rs
@@ -1,4 +1,4 @@
-use crate::domain::error::{AppError, InvalidKeyError, PathTraversalError, ConfigError};
+use crate::domain::error::{AppError, ConfigError, InvalidKeyError, PathTraversalError};
 use crate::domain::ports::{Clipboard, SnippetStore};
 use crate::domain::snippet::SnippetFrontmatter;
 use std::path::{Path, PathBuf};
@@ -21,7 +21,9 @@ fn extract_relative_path(raw_path: &str) -> Result<PathBuf, AppError> {
     })?;
 
     if stripped.is_empty() {
-        return Err(AppError::InvalidKey(InvalidKeyError::EmptyAfterPrefix(".mx/commands/".to_string())));
+        return Err(AppError::InvalidKey(InvalidKeyError::EmptyAfterPrefix(
+            ".mx/commands/".to_string(),
+        )));
     }
 
     let rel = Path::new(stripped);
@@ -129,7 +131,10 @@ mod tests {
         execute(".mx/commands/dup.md", None, None, false, &store, &clipboard).unwrap();
         let err = execute(".mx/commands/dup.md", None, None, false, &store, &clipboard)
             .expect_err("should fail on duplicate");
-        assert!(matches!(err, AppError::ConfigError(crate::domain::error::ConfigError::DuplicateSnippet(_))));
+        assert!(matches!(
+            err,
+            AppError::ConfigError(crate::domain::error::ConfigError::DuplicateSnippet(_))
+        ));
     }
 
     #[test]
@@ -150,6 +155,9 @@ mod tests {
 
         let err = execute("foo/bar.md", None, None, false, &store, &clipboard)
             .expect_err("should reject path outside .mx/commands/");
-        assert!(matches!(err, AppError::InvalidKey(crate::domain::error::InvalidKeyError::NotInCommands { .. })));
+        assert!(matches!(
+            err,
+            AppError::InvalidKey(crate::domain::error::InvalidKeyError::NotInCommands { .. })
+        ));
     }
 }

--- a/src/app/commands/cat/mod.rs
+++ b/src/app/commands/cat/mod.rs
@@ -33,6 +33,6 @@ mod tests {
     fn execute_rejects_path_traversal() {
         let store = InMemoryContextStore::default();
         let result = execute("../secret", &store);
-        assert!(matches!(result, Err(AppError::PathTraversal(_))));
+        assert!(matches!(result, Err(AppError::PathTraversal(crate::domain::error::PathTraversalError::Detected(_)))));
     }
 }

--- a/src/app/commands/cat/mod.rs
+++ b/src/app/commands/cat/mod.rs
@@ -33,6 +33,9 @@ mod tests {
     fn execute_rejects_path_traversal() {
         let store = InMemoryContextStore::default();
         let result = execute("../secret", &store);
-        assert!(matches!(result, Err(AppError::PathTraversal(crate::domain::error::PathTraversalError::Detected(_)))));
+        assert!(matches!(
+            result,
+            Err(AppError::PathTraversal(crate::domain::error::PathTraversalError::Detected(_)))
+        ));
     }
 }

--- a/src/app/commands/copy/mod.rs
+++ b/src/app/commands/copy/mod.rs
@@ -140,7 +140,10 @@ mod tests {
 
         let error = execute("unknown", &catalog, &clipboard, Some(&workspace_store))
             .expect_err("missing snippet should fail");
-        assert!(matches!(error, AppError::NotFound(crate::domain::error::NotFoundError::Snippet(_))));
+        assert!(matches!(
+            error,
+            AppError::NotFound(crate::domain::error::NotFoundError::Snippet(_))
+        ));
     }
 
     #[test]

--- a/src/app/commands/copy/mod.rs
+++ b/src/app/commands/copy/mod.rs
@@ -140,7 +140,7 @@ mod tests {
 
         let error = execute("unknown", &catalog, &clipboard, Some(&workspace_store))
             .expect_err("missing snippet should fail");
-        assert!(matches!(error, AppError::NotFound(_)));
+        assert!(matches!(error, AppError::NotFound(crate::domain::error::NotFoundError::Snippet(_))));
     }
 
     #[test]

--- a/src/app/commands/create_command/mod.rs
+++ b/src/app/commands/create_command/mod.rs
@@ -1,4 +1,4 @@
-use crate::domain::error::AppError;
+use crate::domain::error::{AppError, ConfigError, InvalidKeyError, PathTraversalError};
 use crate::domain::ports::SnippetStore;
 use std::path::{Path, PathBuf};
 
@@ -13,27 +13,30 @@ pub struct CreateCommandOutcome {
 fn extract_relative_path(raw_path: &str) -> Result<PathBuf, AppError> {
     let normalized = raw_path.trim_start_matches("./");
     let stripped = normalized.strip_prefix(".mx/commands/").ok_or_else(|| {
-        AppError::invalid_key(format!("Path must be under .mx/commands/ (got '{raw_path}')"))
+        AppError::InvalidKey(InvalidKeyError::NotInCommands {
+            expected: ".mx/commands/".to_string(),
+            actual: raw_path.to_string(),
+        })
     })?;
 
     if stripped.is_empty() {
-        return Err(AppError::invalid_key("Path cannot be empty after .mx/commands/"));
+        return Err(AppError::InvalidKey(InvalidKeyError::EmptyAfterPrefix(".mx/commands/".to_string())));
     }
 
     // Reject raw dot/double-dot segments before path normalization erases them.
     for segment in stripped.split('/') {
         if segment == "." || segment == ".." || segment.is_empty() {
-            return Err(AppError::path_traversal(format!(
+            return Err(AppError::PathTraversal(PathTraversalError::Detected(format!(
                 "Path contains unsafe segments: '{raw_path}'"
-            )));
+            ))));
         }
     }
 
     let rel = Path::new(stripped);
     if rel.extension().map(|e| e != "md").unwrap_or(false) {
-        return Err(AppError::invalid_key(format!(
+        return Err(AppError::InvalidKey(InvalidKeyError::Other(format!(
             "Path must have a .md extension (got '{raw_path}')"
-        )));
+        ))));
     }
 
     Ok(rel.to_path_buf())
@@ -47,10 +50,10 @@ pub fn execute(
     let relative = extract_relative_path(raw_path)?;
 
     if store.snippet_exists(&relative) && !force {
-        return Err(AppError::config_error(format!(
+        return Err(AppError::ConfigError(ConfigError::DuplicateSnippet(format!(
             "Snippet already exists: '{}'. Use --force to overwrite.",
             relative.display()
-        )));
+        ))));
     }
 
     let path = store.write_snippet(&relative, TEMPLATE)?;
@@ -58,7 +61,7 @@ pub fn execute(
         .file_stem()
         .and_then(|s| s.to_str())
         .ok_or_else(|| {
-            AppError::invalid_key(format!("Path must end with a valid filename: '{raw_path}'"))
+            AppError::InvalidKey(InvalidKeyError::NoFilename(raw_path.to_string()))
         })?
         .to_string();
 

--- a/src/app/commands/create_command/mod.rs
+++ b/src/app/commands/create_command/mod.rs
@@ -20,7 +20,9 @@ fn extract_relative_path(raw_path: &str) -> Result<PathBuf, AppError> {
     })?;
 
     if stripped.is_empty() {
-        return Err(AppError::InvalidKey(InvalidKeyError::EmptyAfterPrefix(".mx/commands/".to_string())));
+        return Err(AppError::InvalidKey(InvalidKeyError::EmptyAfterPrefix(
+            ".mx/commands/".to_string(),
+        )));
     }
 
     // Reject raw dot/double-dot segments before path normalization erases them.
@@ -60,9 +62,7 @@ pub fn execute(
     let key = relative
         .file_stem()
         .and_then(|s| s.to_str())
-        .ok_or_else(|| {
-            AppError::InvalidKey(InvalidKeyError::NoFilename(raw_path.to_string()))
-        })?
+        .ok_or_else(|| AppError::InvalidKey(InvalidKeyError::NoFilename(raw_path.to_string())))?
         .to_string();
 
     Ok(CreateCommandOutcome { key, path })

--- a/src/app/commands/remove/mod.rs
+++ b/src/app/commands/remove/mod.rs
@@ -51,6 +51,6 @@ mod tests {
         let store = InMemorySnippetStore::new();
 
         let err = execute("missing", &catalog, &store).expect_err("should fail");
-        assert!(matches!(err, AppError::NotFound(_)));
+        assert!(matches!(err, AppError::NotFound(crate::domain::error::NotFoundError::Snippet(_))));
     }
 }

--- a/src/domain/context_file/path_policy.rs
+++ b/src/domain/context_file/path_policy.rs
@@ -8,7 +8,11 @@ pub(crate) fn validate_relative_components(path: &Path) -> Result<(), AppError> 
         match component {
             std::path::Component::Normal(_) | std::path::Component::CurDir => {}
             _ => {
-                return Err(AppError::PathTraversal(crate::domain::error::PathTraversalError::Detected(PATH_TRAVERSAL_MESSAGE.to_string())));
+                return Err(AppError::PathTraversal(
+                    crate::domain::error::PathTraversalError::Detected(
+                        PATH_TRAVERSAL_MESSAGE.to_string(),
+                    ),
+                ));
             }
         }
     }

--- a/src/domain/context_file/path_policy.rs
+++ b/src/domain/context_file/path_policy.rs
@@ -8,7 +8,7 @@ pub(crate) fn validate_relative_components(path: &Path) -> Result<(), AppError> 
         match component {
             std::path::Component::Normal(_) | std::path::Component::CurDir => {}
             _ => {
-                return Err(AppError::path_traversal(PATH_TRAVERSAL_MESSAGE));
+                return Err(AppError::PathTraversal(crate::domain::error::PathTraversalError::Detected(PATH_TRAVERSAL_MESSAGE.to_string())));
             }
         }
     }

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -5,43 +5,87 @@ pub enum AppError {
     #[error(transparent)]
     Io(#[from] io::Error),
 
-    #[error("{0}")]
-    ConfigError(String),
+    #[error(transparent)]
+    ConfigError(#[from] ConfigError),
 
-    #[error("{0}")]
-    NotFound(String),
+    #[error(transparent)]
+    NotFound(#[from] NotFoundError),
 
-    #[error("{0}")]
-    ClipboardError(String),
+    #[error(transparent)]
+    ClipboardError(#[from] ClipboardError),
 
+    #[error(transparent)]
+    InvalidKey(#[from] InvalidKeyError),
+
+    #[error(transparent)]
+    PathTraversal(#[from] PathTraversalError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConfigError {
+    #[error("Missing environment variable: {0}")]
+    MissingEnvVar(String),
+    #[error("Duplicate snippet: {0}")]
+    DuplicateSnippet(String),
+    #[error("Empty snippet name")]
+    EmptySnippetName,
+    #[error("Invalid UTF-8 in snippet path")]
+    InvalidUtf8,
+    #[error("Unable to derive relative path for: {0}")]
+    RelativePathDerivation(String),
+    #[error("File system error: {0}")]
+    Io(String),
+    #[error("Configuration error: {0}")]
+    Other(String),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum NotFoundError {
+    #[error("Snippet not found: {0}")]
+    Snippet(String),
+    #[error("Context file not found: {0}")]
+    ContextFile(String),
+    #[error("File not found: {0}")]
+    File(String),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ClipboardError {
+    #[error("Command not found or empty: {0}")]
+    CommandMissing(String),
+    #[error("Unsupported platform: {0}")]
+    UnsupportedPlatform(String),
+    #[error("Command execution failed: {0}")]
+    ExecutionFailed(String),
+    #[error("Command exited with non-zero status: {0}")]
+    NonZeroExit(i32),
+    #[error("Invalid UTF-8 in clipboard content: {0}")]
+    InvalidUtf8(String),
+    #[error("Clipboard Error: {0}")]
+    Other(String),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum InvalidKeyError {
+    #[error("Path must be under {expected} (got '{actual}')")]
+    NotInCommands { expected: String, actual: String },
+    #[error("Path cannot be empty after {0}")]
+    EmptyAfterPrefix(String),
+    #[error("Path must end with a valid filename: '{0}'")]
+    NoFilename(String),
+    #[error("Directory already exists for key: {0}")]
+    DirectoryExists(String),
     #[error("Invalid key: {0}")]
-    InvalidKey(String),
+    Other(String),
+}
 
-    #[error("{0}")]
-    PathTraversal(String),
+#[derive(thiserror::Error, Debug)]
+pub enum PathTraversalError {
+    #[error("Path traversal detected: {0}")]
+    Detected(String),
 }
 
 impl AppError {
-    pub(crate) fn config_error<S: Into<String>>(message: S) -> Self {
-        Self::ConfigError(message.into())
-    }
-
-    pub(crate) fn not_found<S: Into<String>>(message: S) -> Self {
-        Self::NotFound(message.into())
-    }
-
-    pub(crate) fn clipboard_error<S: Into<String>>(message: S) -> Self {
-        Self::ClipboardError(message.into())
-    }
-
-    pub fn invalid_key<S: Into<String>>(message: S) -> Self {
-        Self::InvalidKey(message.into())
-    }
-
-    pub fn path_traversal<S: Into<String>>(message: S) -> Self {
-        Self::PathTraversal(message.into())
-    }
-
     pub fn kind(&self) -> io::ErrorKind {
         match self {
             Self::Io(err) => err.kind(),

--- a/src/domain/snippet/query.rs
+++ b/src/domain/snippet/query.rs
@@ -52,7 +52,7 @@ pub fn path_to_string(path: &Path) -> Result<String, AppError> {
             Component::Normal(segment) => parts.push(
                 segment
                     .to_str()
-                    .ok_or_else(|| AppError::ConfigError(ConfigError::InvalidUtf8))?
+                    .ok_or(AppError::ConfigError(ConfigError::InvalidUtf8))?
                     .to_string(),
             ),
             Component::CurDir => continue,

--- a/src/domain/snippet/query.rs
+++ b/src/domain/snippet/query.rs
@@ -1,10 +1,10 @@
-use crate::domain::error::AppError;
+use crate::domain::error::{AppError, ConfigError};
 use std::path::{Component, Path};
 
 pub fn normalize_query(raw: &str) -> Result<String, AppError> {
     let trimmed = raw.trim().trim_start_matches('/');
     if trimmed.is_empty() {
-        return Err(AppError::config_error("Snippet name cannot be empty"));
+        return Err(AppError::ConfigError(ConfigError::EmptySnippetName));
     }
 
     let mut normalized = trimmed.replace('\\', "/");
@@ -25,18 +25,18 @@ pub fn candidate_key(normalized_query: &str) -> String {
 
 pub fn ensure_safe_segments(value: &str) -> Result<(), AppError> {
     if value.split('/').any(|segment| segment.is_empty()) {
-        return Err(AppError::config_error(
-            "Snippet paths cannot contain empty, absolute, or traversal segments",
-        ));
+        return Err(AppError::ConfigError(ConfigError::Other(
+            "Snippet paths cannot contain empty, absolute, or traversal segments".to_string(),
+        )));
     }
 
     for component in Path::new(value).components() {
         match component {
             Component::Normal(_) | Component::CurDir => {}
             _ => {
-                return Err(AppError::config_error(
-                    "Snippet paths cannot contain empty, absolute, or traversal segments",
-                ));
+                return Err(AppError::ConfigError(ConfigError::Other(
+                    "Snippet paths cannot contain empty, absolute, or traversal segments".to_string(),
+                )));
             }
         }
     }
@@ -51,14 +51,14 @@ pub fn path_to_string(path: &Path) -> Result<String, AppError> {
             Component::Normal(segment) => parts.push(
                 segment
                     .to_str()
-                    .ok_or_else(|| AppError::config_error("Snippet paths must be UTF-8"))?
+                    .ok_or_else(|| AppError::ConfigError(ConfigError::InvalidUtf8))?
                     .to_string(),
             ),
             Component::CurDir => continue,
             _ => {
-                return Err(AppError::config_error(
-                    "Snippet paths cannot include traversal components",
-                ));
+                return Err(AppError::ConfigError(ConfigError::Other(
+                    "Snippet paths cannot include traversal components".to_string(),
+                )));
             }
         }
     }

--- a/src/domain/snippet/query.rs
+++ b/src/domain/snippet/query.rs
@@ -35,7 +35,8 @@ pub fn ensure_safe_segments(value: &str) -> Result<(), AppError> {
             Component::Normal(_) | Component::CurDir => {}
             _ => {
                 return Err(AppError::ConfigError(ConfigError::Other(
-                    "Snippet paths cannot contain empty, absolute, or traversal segments".to_string(),
+                    "Snippet paths cannot contain empty, absolute, or traversal segments"
+                        .to_string(),
                 )));
             }
         }

--- a/src/testing/ports/in_memory_catalog.rs
+++ b/src/testing/ports/in_memory_catalog.rs
@@ -31,11 +31,11 @@ impl SnippetCatalog for InMemoryCatalog {
         }
 
         if key_match.len() > 1 {
-            return Err(AppError::config_error(format!(
+            return Err(AppError::ConfigError(crate::domain::error::ConfigError::Other(format!(
                 "Multiple snippets share the name '{raw_query}'",
-            )));
+            ))));
         }
 
-        Err(AppError::not_found(format!("No snippet named '{raw_query}'")))
+        Err(AppError::NotFound(crate::domain::error::NotFoundError::Snippet(format!("No snippet named '{raw_query}'"))))
     }
 }

--- a/src/testing/ports/in_memory_catalog.rs
+++ b/src/testing/ports/in_memory_catalog.rs
@@ -36,6 +36,8 @@ impl SnippetCatalog for InMemoryCatalog {
             ))));
         }
 
-        Err(AppError::NotFound(crate::domain::error::NotFoundError::Snippet(format!("No snippet named '{raw_query}'"))))
+        Err(AppError::NotFound(crate::domain::error::NotFoundError::Snippet(format!(
+            "No snippet named '{raw_query}'"
+        ))))
     }
 }

--- a/src/testing/ports/in_memory_context_store.rs
+++ b/src/testing/ports/in_memory_context_store.rs
@@ -41,7 +41,10 @@ impl ContextFileStore for InMemoryContextStore {
     fn read_context_contents(&self, relative_path: &Path) -> Result<String, AppError> {
         let path = PathBuf::from(".mx").join(relative_path);
         self.files.borrow().get(&path).cloned().ok_or_else(|| {
-            AppError::NotFound(crate::domain::error::NotFoundError::ContextFile(format!("⚠️ Context file not found: {}", relative_path.display())))
+            AppError::NotFound(crate::domain::error::NotFoundError::ContextFile(format!(
+                "⚠️ Context file not found: {}",
+                relative_path.display()
+            )))
         })
     }
 
@@ -57,7 +60,10 @@ impl ContextFileStore for InMemoryContextStore {
             return Ok(path);
         }
 
-        Err(AppError::NotFound(crate::domain::error::NotFoundError::ContextFile(format!("File not found: {}", path.display()))))
+        Err(AppError::NotFound(crate::domain::error::NotFoundError::ContextFile(format!(
+            "File not found: {}",
+            path.display()
+        ))))
     }
 
     fn read_workspace_file(&self, relative_path: &Path) -> Result<String, std::io::Error> {

--- a/src/testing/ports/in_memory_context_store.rs
+++ b/src/testing/ports/in_memory_context_store.rs
@@ -41,7 +41,7 @@ impl ContextFileStore for InMemoryContextStore {
     fn read_context_contents(&self, relative_path: &Path) -> Result<String, AppError> {
         let path = PathBuf::from(".mx").join(relative_path);
         self.files.borrow().get(&path).cloned().ok_or_else(|| {
-            AppError::not_found(format!("⚠️ Context file not found: {}", relative_path.display()))
+            AppError::NotFound(crate::domain::error::NotFoundError::ContextFile(format!("⚠️ Context file not found: {}", relative_path.display())))
         })
     }
 
@@ -57,7 +57,7 @@ impl ContextFileStore for InMemoryContextStore {
             return Ok(path);
         }
 
-        Err(AppError::not_found(format!("File not found: {}", path.display())))
+        Err(AppError::NotFound(crate::domain::error::NotFoundError::ContextFile(format!("File not found: {}", path.display()))))
     }
 
     fn read_workspace_file(&self, relative_path: &Path) -> Result<String, std::io::Error> {

--- a/src/testing/ports/in_memory_snippet_store.rs
+++ b/src/testing/ports/in_memory_snippet_store.rs
@@ -56,7 +56,9 @@ impl SnippetStore for InMemorySnippetStore {
         let k = key(relative_path);
         let mut files = self.files.lock().unwrap();
         if files.remove(&k).is_none() {
-            return Err(AppError::NotFound(crate::domain::error::NotFoundError::Snippet(format!("Snippet not found: {k}"))));
+            return Err(AppError::NotFound(crate::domain::error::NotFoundError::Snippet(format!(
+                "Snippet not found: {k}"
+            ))));
         }
         Ok(PathBuf::from(k))
     }

--- a/src/testing/ports/in_memory_snippet_store.rs
+++ b/src/testing/ports/in_memory_snippet_store.rs
@@ -56,7 +56,7 @@ impl SnippetStore for InMemorySnippetStore {
         let k = key(relative_path);
         let mut files = self.files.lock().unwrap();
         if files.remove(&k).is_none() {
-            return Err(AppError::not_found(format!("Snippet not found: {k}")));
+            return Err(AppError::NotFound(crate::domain::error::NotFoundError::Snippet(format!("Snippet not found: {k}"))));
         }
         Ok(PathBuf::from(k))
     }


### PR DESCRIPTION
This PR addresses the technical debt around generic "stringly-typed" errors in the codebase by redefining `AppError`. It eliminates unstructured variants like `ConfigError(String)` and `NotFound(String)`, replacing them with dedicated types that model domain failures semantically (`ConfigError::DuplicateSnippet`, `NotFoundError::File`, `ClipboardError::ExecutionFailed`). All adapters, domain logic, commands, and tests have been updated to consume and assert against these robust variants.

---
*PR created automatically by Jules for task [17590379473247941291](https://jules.google.com/task/17590379473247941291) started by @akitorahayashi*